### PR TITLE
A couple edits to facilitate importing this via WORKSPACE.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_prefix")
 
 go_prefix("github.com/google/build-crd")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,12 +95,6 @@ exports_files(glob(["**/cloudbuild.yaml"]))
 """,
 )
 
-# Pull in the go_image stuff.
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+load(":deps.bzl", "repositories")
 
-container_pull(
-    name = "git_base",
-    registry = "gcr.io",
-    repository = "cloud-builders/git",
-    tag = "latest",
-)
+repositories()

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+def repositories():
+  container_pull(
+      name = "git_base",
+      registry = "gcr.io",
+      repository = "cloud-builders/git",
+      tag = "latest",
+  )

--- a/pkg/apis/cloudbuild/v1alpha1/BUILD
+++ b/pkg/apis/cloudbuild/v1alpha1/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(


### PR DESCRIPTION
Until we start cutting releases (e.g. `bazel run :everything > release.yaml` w/ a public `DOCKER_REPO_OVERRIDE`) this enables other repositories to import a particular commit from this repository and build/deploy it alongside other components.