### PR TITLE
This moves the validation logic into an interface.

### DIFF
--- a/pkg/builder/cluster/builder.go
+++ b/pkg/builder/cluster/builder.go
@@ -151,6 +151,10 @@ func (b *builder) Builder() v1alpha1.BuildProvider {
 	return v1alpha1.ClusterBuildProvider
 }
 
+func (b *builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) *buildercommon.ValidationError {
+	return buildercommon.ValidateBuild(u, tmpl)
+}
+
 func (b *builder) BuildFromSpec(u *v1alpha1.Build) (buildercommon.Build, error) {
 	bld, err := convert.FromCRD(u)
 	if err != nil {

--- a/pkg/builder/google/builder.go
+++ b/pkg/builder/google/builder.go
@@ -129,6 +129,10 @@ func (b *builder) Builder() v1alpha1.BuildProvider {
 	return v1alpha1.GoogleBuildProvider
 }
 
+func (b *builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) *buildercommon.ValidationError {
+	return buildercommon.ValidateBuild(u, tmpl)
+}
+
 func (b *builder) BuildFromSpec(u *v1alpha1.Build) (buildercommon.Build, error) {
 	bld, err := convert.FromCRD(&u.Spec)
 	if err != nil {

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -47,6 +47,9 @@ type Interface interface {
 	// Which builder are we?
 	Builder() v1alpha1.BuildProvider
 
+	// Validate a Build for this flavor of builder.
+	Validate(*v1alpha1.Build, *v1alpha1.BuildTemplate) *ValidationError
+
 	// Construct a Build for this flavor of builder from our CRD specification.
 	BuildFromSpec(*v1alpha1.Build) (Build, error)
 

--- a/pkg/builder/nop/builder.go
+++ b/pkg/builder/nop/builder.go
@@ -107,6 +107,10 @@ func (nb *Builder) Builder() v1alpha1.BuildProvider {
 	return v1alpha1.GoogleBuildProvider
 }
 
+func (nb *Builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) *buildercommon.ValidationError {
+	return buildercommon.ValidateBuild(u, tmpl)
+}
+
 func (nb *Builder) BuildFromSpec(*v1alpha1.Build) (buildercommon.Build, error) {
 	return &build{builder: nb}, nil
 }

--- a/pkg/controller/build/controller.go
+++ b/pkg/controller/build/controller.go
@@ -301,7 +301,7 @@ func (c *Controller) syncHandler(key string) error {
 					return err
 				}
 			}
-			if verr := builder.ValidateBuild(build, tmpl); verr != nil {
+			if verr := c.builder.Validate(build, tmpl); verr != nil {
 				build.Status.SetCondition(v1alpha1.BuildInvalid, &v1alpha1.BuildCondition{
 					Type:               v1alpha1.BuildInvalid,
 					Status:             corev1.ConditionTrue,


### PR DESCRIPTION
Right now these simply call the common validation logic, but the hooks enable us to perform more tailored validation.

I will start looking at moving some of the "lost in translation" failures into validation errors next.

Fixes: https://github.com/google/build-crd/issues/12