### PR TITLE
Make the validation callbacks attempt conversions.

### DIFF
--- a/pkg/builder/cluster/builder.go
+++ b/pkg/builder/cluster/builder.go
@@ -151,8 +151,14 @@ func (b *builder) Builder() v1alpha1.BuildProvider {
 	return v1alpha1.ClusterBuildProvider
 }
 
-func (b *builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) *buildercommon.ValidationError {
-	return buildercommon.ValidateBuild(u, tmpl)
+func (b *builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) error {
+	if err := buildercommon.ValidateBuild(u, tmpl); err != nil {
+		return err
+	}
+	if _, err := convert.FromCRD(u); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *builder) BuildFromSpec(u *v1alpha1.Build) (buildercommon.Build, error) {

--- a/pkg/builder/cluster/convert/BUILD
+++ b/pkg/builder/cluster/convert/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/cloudbuild/v1alpha1:go_default_library",
+        "//pkg/builder:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/builder/google/builder.go
+++ b/pkg/builder/google/builder.go
@@ -129,8 +129,14 @@ func (b *builder) Builder() v1alpha1.BuildProvider {
 	return v1alpha1.GoogleBuildProvider
 }
 
-func (b *builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) *buildercommon.ValidationError {
-	return buildercommon.ValidateBuild(u, tmpl)
+func (b *builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) error {
+	if err := buildercommon.ValidateBuild(u, tmpl); err != nil {
+		return err
+	}
+	if _, err := convert.FromCRD(&u.Spec); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *builder) BuildFromSpec(u *v1alpha1.Build) (buildercommon.Build, error) {

--- a/pkg/builder/google/convert/BUILD
+++ b/pkg/builder/google/convert/BUILD
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/cloudbuild/v1alpha1:go_default_library",
+        "//pkg/builder:go_default_library",
         "//vendor/google.golang.org/api/cloudbuild/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/pkg/builder/google/convert/source.go
+++ b/pkg/builder/google/convert/source.go
@@ -23,6 +23,8 @@ import (
 	"google.golang.org/api/cloudbuild/v1"
 
 	v1alpha1 "github.com/google/build-crd/pkg/apis/cloudbuild/v1alpha1"
+
+	"github.com/google/build-crd/pkg/builder"
 )
 
 var (
@@ -32,7 +34,11 @@ var (
 func ToRepoSourceFromGit(og *v1alpha1.GitSourceSpec) (*cloudbuild.RepoSource, error) {
 	if !csr.MatchString(og.Url) {
 		// TODO(mattmoor): This could fall back on logic as in the on-cluster builder.
-		return nil, fmt.Errorf("git.url must match %v for the Google builder, got %q", csr, og.Url)
+		// https://github.com/google/build-crd/issues/22
+		return nil, &builder.ValidationError{
+			Reason:  "UnsupportedGitUrl",
+			Message: fmt.Sprint("git.url must match %v for the Google builder, got %q", csr, og.Url),
+		}
 	}
 	// Extract the capture groups.
 	match := csr.FindStringSubmatch(og.Url)
@@ -59,16 +65,25 @@ func ToRepoSourceFromGit(og *v1alpha1.GitSourceSpec) (*cloudbuild.RepoSource, er
 			BranchName: og.Branch,
 		}, nil
 	case og.Ref != "":
-		return nil, fmt.Errorf("git.ref is unsupported by the Googler builder, got: %v", og.Ref)
+		return nil, &builder.ValidationError{
+			Reason:  "UnsupportedRef",
+			Message: fmt.Sprintf("git.ref is unsupported by the Googler builder, got: %v", og.Ref),
+		}
 	default:
-		return nil, fmt.Errorf("missing one of branch/tag/ref/commit, got: %v", og)
+		return nil, &builder.ValidationError{
+			Reason:  "MissingCommitish",
+			Message: fmt.Sprintf("missing one of branch/tag/ref/commit, got: %v", og),
+		}
 	}
 
 }
 
 func ToGitFromRepoSource(og *cloudbuild.RepoSource) (*v1alpha1.GitSourceSpec, error) {
 	if og.Dir != "" {
-		return nil, fmt.Errorf("the Build CRD doesn't support 'dir', got: %v", og.Dir)
+		return nil, &builder.ValidationError{
+			Reason:  "UnsupportedDir",
+			Message: fmt.Sprintf("the Build CRD doesn't support 'dir', got: %v", og.Dir),
+		}
 	}
 	return &v1alpha1.GitSourceSpec{
 		Url:    fmt.Sprintf("https://source.developers.google.com/p/%s/r/%s", og.ProjectId, og.RepoName),

--- a/pkg/builder/google/convert/step.go
+++ b/pkg/builder/google/convert/step.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"google.golang.org/api/cloudbuild/v1"
+
+	"github.com/google/build-crd/pkg/builder"
 )
 
 func ToContainerFromStep(og *cloudbuild.BuildStep) (*corev1.Container, error) {
@@ -65,7 +67,10 @@ func ToStepFromContainer(og *corev1.Container) (*cloudbuild.BuildStep, error) {
 		// TODO(mattmoor): This is a restriction we should eliminate.  It also isn't clear that this
 		// is 100% fidelity translation, since Dockerfile's scalar vs. list semantics are not what this
 		// is doing (though the semantics of GCB and Kubernetes aren't necessarily 1:1 with that).
-		return nil, fmt.Errorf("the Build CRD doesn't support multi-element commands, got: %v", og.Command)
+		return nil, &builder.ValidationError{
+			Reason:  "UnsupportedCommand",
+			Message: fmt.Sprintf("the Google builder doesn't support multi-element commands, got: %v", og.Command),
+		}
 	}
 	return &cloudbuild.BuildStep{
 		Id:         og.Name,

--- a/pkg/builder/google/convert/volume.go
+++ b/pkg/builder/google/convert/volume.go
@@ -22,6 +22,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"google.golang.org/api/cloudbuild/v1"
+
+	"github.com/google/build-crd/pkg/builder"
 )
 
 func ToVolumeMountFromVolume(og *cloudbuild.Volume) (*corev1.VolumeMount, error) {
@@ -33,13 +35,22 @@ func ToVolumeMountFromVolume(og *cloudbuild.Volume) (*corev1.VolumeMount, error)
 
 func ToVolumeFromVolumeMount(og *corev1.VolumeMount) (*cloudbuild.Volume, error) {
 	if og.ReadOnly {
-		return nil, fmt.Errorf("the Build CRD does not support ReadOnly volumes, got: %v", og)
+		return nil, &builder.ValidationError{
+			Reason:  "ReadOnly",
+			Message: fmt.Sprintf("container builder does not support ReadOnly volumes, got: %v", og),
+		}
 	}
 	if og.MountPropagation != nil {
-		return nil, fmt.Errorf("the Build CRD does not support mountPropagation on volumes, got: %v", og)
+		return nil, &builder.ValidationError{
+			Reason:  "MountPropagation",
+			Message: fmt.Sprintf("container builder does not support mountPropagation on volumes, got: %v", og),
+		}
 	}
 	if og.SubPath != "" {
-		return nil, fmt.Errorf("the Build CRD does not support subPath on volumes, got: %v", og)
+		return nil, &builder.ValidationError{
+			Reason:  "VolumeSubpath",
+			Message: fmt.Sprintf("container builder does not support subPath on volumes, got: %v", og),
+		}
 	}
 
 	return &cloudbuild.Volume{

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -48,7 +48,7 @@ type Interface interface {
 	Builder() v1alpha1.BuildProvider
 
 	// Validate a Build for this flavor of builder.
-	Validate(*v1alpha1.Build, *v1alpha1.BuildTemplate) *ValidationError
+	Validate(*v1alpha1.Build, *v1alpha1.BuildTemplate) error
 
 	// Construct a Build for this flavor of builder from our CRD specification.
 	BuildFromSpec(*v1alpha1.Build) (Build, error)

--- a/pkg/builder/nop/builder.go
+++ b/pkg/builder/nop/builder.go
@@ -107,7 +107,7 @@ func (nb *Builder) Builder() v1alpha1.BuildProvider {
 	return v1alpha1.GoogleBuildProvider
 }
 
-func (nb *Builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) *buildercommon.ValidationError {
+func (nb *Builder) Validate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) error {
 	return buildercommon.ValidateBuild(u, tmpl)
 }
 

--- a/pkg/builder/validate.go
+++ b/pkg/builder/validate.go
@@ -36,14 +36,14 @@ func (ve *ValidationError) Error() string {
 	return fmt.Sprintf("%s: %s", ve.Reason, ve.Message)
 }
 
-func validationError(reason, format string, fmtArgs ...interface{}) *ValidationError {
+func validationError(reason, format string, fmtArgs ...interface{}) error {
 	return &ValidationError{
 		Reason:  reason,
 		Message: fmt.Sprintf(format, fmtArgs...),
 	}
 }
 
-func validateSteps(steps []corev1.Container) *ValidationError {
+func validateSteps(steps []corev1.Container) error {
 	// Build must not duplicate step names.
 	names := map[string]struct{}{}
 	for _, s := range steps {
@@ -58,7 +58,7 @@ func validateSteps(steps []corev1.Container) *ValidationError {
 	return nil
 }
 
-func validateVolumes(volumes []corev1.Volume) *ValidationError {
+func validateVolumes(volumes []corev1.Volume) error {
 	// Build must not duplicate volume names.
 	vols := map[string]struct{}{}
 	for _, v := range volumes {
@@ -72,7 +72,7 @@ func validateVolumes(volumes []corev1.Volume) *ValidationError {
 
 // ValidateBuild returns a ValidationError if the build and optional template do not
 // specify a valid build.
-func ValidateBuild(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) *ValidationError {
+func ValidateBuild(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) error {
 	if u.Spec.Template != nil && len(u.Spec.Steps) > 0 {
 		return validationError("TemplateAndSteps", "build cannot specify both template and steps")
 	}
@@ -105,7 +105,7 @@ func ValidateBuild(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) *ValidationE
 	return nil
 }
 
-func validateArguments(args []v1alpha1.ArgumentSpec, tmpl *v1alpha1.BuildTemplate) *ValidationError {
+func validateArguments(args []v1alpha1.ArgumentSpec, tmpl *v1alpha1.BuildTemplate) error {
 	// Build must not duplicate argument names.
 	seen := map[string]struct{}{}
 	for _, a := range args {
@@ -139,7 +139,7 @@ func validateArguments(args []v1alpha1.ArgumentSpec, tmpl *v1alpha1.BuildTemplat
 }
 
 // ValidateTemplate returns a ValidationError if the build template is invalid.
-func ValidateTemplate(tmpl *v1alpha1.BuildTemplate) *ValidationError {
+func ValidateTemplate(tmpl *v1alpha1.BuildTemplate) error {
 	if err := validateSteps(tmpl.Spec.Steps); err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func ValidateTemplate(tmpl *v1alpha1.BuildTemplate) *ValidationError {
 	return nil
 }
 
-func validateParameters(params []v1alpha1.ParameterSpec) *ValidationError {
+func validateParameters(params []v1alpha1.ParameterSpec) error {
 	// Template must not duplicate parameter names.
 	seen := map[string]struct{}{}
 	for _, p := range params {
@@ -167,7 +167,7 @@ func validateParameters(params []v1alpha1.ParameterSpec) *ValidationError {
 	return nil
 }
 
-func validatePlaceholders(steps []corev1.Container) *ValidationError {
+func validatePlaceholders(steps []corev1.Container) error {
 	for si, s := range steps {
 		if nestedPlaceholderRE.MatchString(s.Name) {
 			return validationError("NestedPlaceholder", "nested placeholder in step name %d: %q", si, s.Name)

--- a/pkg/controller/build/controller.go
+++ b/pkg/controller/build/controller.go
@@ -301,7 +301,11 @@ func (c *Controller) syncHandler(key string) error {
 					return err
 				}
 			}
-			if verr := c.builder.Validate(build, tmpl); verr != nil {
+			if err := c.builder.Validate(build, tmpl); err != nil {
+				verr, ok := err.(*builder.ValidationError)
+				if !ok {
+					return err
+				}
 				build.Status.SetCondition(v1alpha1.BuildInvalid, &v1alpha1.BuildCondition{
 					Type:               v1alpha1.BuildInvalid,
 					Status:             corev1.ConditionTrue,

--- a/pkg/controller/buildtemplate/controller.go
+++ b/pkg/controller/buildtemplate/controller.go
@@ -254,7 +254,11 @@ func (c *Controller) syncHandler(key string) error {
 	tmpl = tmpl.DeepCopy()
 
 	// TODO(mattmoor): Consider making this specific to a particular builder implementation.
-	if verr := builder.ValidateTemplate(tmpl); verr != nil {
+	if err := builder.ValidateTemplate(tmpl); err != nil {
+		verr, ok := err.(*builder.ValidationError)
+		if !ok {
+			return err
+		}
 		tmpl.Status.SetCondition(v1alpha1.BuildTemplateInvalid, &v1alpha1.BuildTemplateCondition{
 			Type:               v1alpha1.BuildTemplateInvalid,
 			Status:             corev1.ConditionTrue,


### PR DESCRIPTION
This changes the convert.{To,From}CRD methods in the respective builders to use `ValidationError` as its `error` of choice.  This enables us to simply attempt a `convert.FromCRD` in the `Validate` callback, and return any errors.

As part of this the actual type on assorted signatures has changed from `ValidationError` to `error` for the reasons in the linked issue.

Fixes: https://github.com/google/build-crd/issues/25
Fixes: https://github.com/google/build-crd/issues/20