### PR TITLE
Apply template substitutions to VolumeMounts

### DIFF
--- a/pkg/builder/common.go
+++ b/pkg/builder/common.go
@@ -68,6 +68,11 @@ func ApplyTemplate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) (*v1alpha1.B
 		for ic, c := range steps[i].Command {
 			steps[i].Command[ic] = applyReplacements(c)
 		}
+		for iv, v := range steps[i].VolumeMounts {
+			steps[i].VolumeMounts[iv].Name = applyReplacements(v.Name)
+			steps[i].VolumeMounts[iv].MountPath = applyReplacements(v.MountPath)
+			steps[i].VolumeMounts[iv].SubPath = applyReplacements(v.SubPath)
+		}
 	}
 
 	return build, nil

--- a/pkg/builder/common_test.go
+++ b/pkg/builder/common_test.go
@@ -103,6 +103,11 @@ func TestApplyTemplate(t *testing.T) {
 					}},
 					Command:    []string{"cmd", "${FOO}"},
 					WorkingDir: "/dir/${FOO}/bar",
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      "${FOO}",
+						MountPath: "path/to/${FOO}",
+						SubPath:   "sub/${FOO}/path",
+					}},
 				}},
 				Parameters: []v1alpha1.ParameterSpec{{
 					Name: "FOO",
@@ -120,6 +125,11 @@ func TestApplyTemplate(t *testing.T) {
 					}},
 					Command:    []string{"cmd", "world"},
 					WorkingDir: "/dir/world/bar",
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      "world",
+						MountPath: "path/to/world",
+						SubPath:   "sub/world/path",
+					}},
 				}},
 				Template: &v1alpha1.TemplateInstantiationSpec{
 					Arguments: []v1alpha1.ArgumentSpec{{


### PR DESCRIPTION
Fixes #55 

I went ahead and also applied substitutions for `mountPath` and `subPath` because I could imagine someone wanting that, maybe.

/cc @sclevine 