### PR TITLE
Run tests before creating build-crd release images

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -43,7 +43,7 @@ header "TEST PHASE"
 
 header "BUILD PHASE"
 
-# Build should not try to push anything, use a bogus value for cluster.
+# Build should not try to deploy anything, use a bogus value for cluster.
 export K8S_CLUSTER_OVERRIDE=CLUSTER_NOT_SET
 
 # Set the repository to the official one:


### PR DESCRIPTION
tests/presubmit-tests.sh is now run before building the images to ensure nothing is broken.

Bonus:
* clearly mark the test and build phases in the output;
* do not depend on any *_OVERRIDE variables to create releases;