### PR TITLE
Add `StepStates []ContainerState` to `BuildStatus`

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -126,7 +126,9 @@ type BuildStatus struct {
 	StartTime      metav1.Time `json:"startTime,omitEmpty"`
 	CompletionTime metav1.Time `json:"completionTime,omitEmpty"`
 
-	Conditions []BuildCondition `json:"conditions,omitempty"`
+	// Parallel list to spec.Containers
+	StepStates []corev1.ContainerState `json:"stepStates,omitEmpty"`
+	Conditions []BuildCondition        `json:"conditions,omitempty"`
 }
 
 type ClusterSpec struct {


### PR DESCRIPTION
This has a couple use cases:

 * Allow clients to monitor (in one place, rather than as a series of gets) the progress of the build, for more dynamic user feedback.

 * Allow us to use Build as a way of getting a piece of information/metadata out of the source (in ContainerStateTerminated.message), rather than only as a way of creating new container images.

This PR is with the intent of opening discussion, not immediately merging.