### PR TITLE
Move the .ssh workaround into git-init

### DIFF
--- a/cmd/git-init/BUILD
+++ b/cmd/git-init/BUILD
@@ -16,25 +16,10 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-
-# HACK HACK HACK
-# Git seems to ignore $HOME/.ssh and look in /root/.ssh for unknown reasons.
-# As a workaround, symlink /root/.ssh to where we expect the $HOME to land.
-# This means SSH auth only works for our built-in git support, and not
-# corev1.Containers.
-container_image(
-    name = "fix_dotssh",
-    base = "@git_base//image",
-    symlinks = {
-        "/root/.ssh": "/builder/home/.ssh",
-    },
-)
-
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_image(
     name = "image",
-    base = ":fix_dotssh",
+    base = "@git_base//image",
     binary = ":git-init",
 )

--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"os"
 	"os/exec"
 
 	"github.com/golang/glog"
@@ -40,6 +41,16 @@ func runOrFail(cmd string, args ...string) {
 
 func main() {
 	flag.Parse()
+
+	// HACK HACK HACK
+	// Git seems to ignore $HOME/.ssh and look in /root/.ssh for unknown reasons.
+	// As a workaround, symlink /root/.ssh to where we expect the $HOME to land.
+	// This means SSH auth only works for our built-in git support, and not
+	// custom steps.
+	err := os.Symlink("/builder/home/.ssh", "/root/.ssh")
+	if err != nil {
+		glog.Fatalf("Unexpected error creating symlink: %v", err)
+	}
 
 	runOrFail("git", "init")
 	runOrFail("git", "remote", "add", "origin", *url)


### PR DESCRIPTION
This moves our workaround where we create the symlink for `.ssh` into the `//cmd/git-init` process at startup.  The motivation for this is to eliminate our reliance on `container_image` to support side-by-side development with `ko`.

The on-cluster integration tests are passing with these modified sidecars:
```shell
$ kubectl get builds -o=custom-columns-file=./tests/columns.txt
NAME                                          BUILDER   TYPE       STATUS    START                  END
test-build-with-serviceaccount-docker-basic   Cluster   Complete   True      2018-04-28T20:24:28Z   2018-04-28T20:26:01Z
test-build-with-serviceaccount-git-ssh        Cluster   Complete   True      2018-04-28T20:24:30Z   2018-04-28T20:25:45Z
test-build-with-serviceaccount-pull-secrets   Cluster   Complete   True      2018-04-28T20:24:25Z   2018-04-28T20:25:38Z
test-configmap                                Cluster   Complete   True      2018-04-28T20:24:15Z   2018-04-28T20:24:20Z
test-custom-env-vars                          Cluster   Complete   True      2018-04-28T20:23:40Z   2018-04-28T20:23:44Z
test-custom-source                            Cluster   Complete   True      2018-04-28T20:23:55Z   2018-04-28T20:25:43Z
test-custom-volume                            Cluster   Complete   True      2018-04-28T20:23:52Z   2018-04-28T20:25:41Z
test-default-workingdir                       Cluster   Complete   True      2018-04-28T20:23:44Z   2018-04-28T20:23:48Z
test-docker-build                             Cluster   Complete   True      2018-04-28T20:24:00Z   2018-04-28T20:26:09Z
test-failure                                  Cluster   Failed     True      2018-04-28T20:24:04Z   2018-04-28T20:24:07Z
test-gcs-archive                              Cluster   Complete   True      2018-04-28T20:24:02Z   2018-04-28T20:25:43Z
test-git-source                               Cluster   Complete   True      2018-04-28T20:24:32Z   2018-04-28T20:25:44Z
test-git-volume                               Cluster   Complete   True      2018-04-28T20:24:16Z   2018-04-28T20:25:59Z
test-home-is-set                              Cluster   Complete   True      2018-04-28T20:23:35Z   2018-04-28T20:23:42Z
test-home-volume                              Cluster   Complete   True      2018-04-28T20:23:51Z   2018-04-28T20:24:01Z
test-panic                                    Cluster   Failed     True      2018-04-28T20:24:09Z   2018-04-28T20:24:11Z
test-secret-env                               Cluster   Complete   True      2018-04-28T20:24:23Z   2018-04-28T20:26:00Z
test-secret-volume                            Cluster   Complete   True      2018-04-28T20:24:17Z   2018-04-28T20:25:40Z
test-template-args                            Cluster   Complete   True      2018-04-28T20:23:57Z   2018-04-28T20:25:40Z
test-template-duplicate-volume                Cluster   Invalid    True      <nil>                  <nil>
test-template-volume                          Cluster   Complete   True      2018-04-28T20:23:54Z   2018-04-28T20:24:04Z
test-unnamed-steps                            Cluster   Complete   True      2018-04-28T20:23:59Z   2018-04-28T20:24:08Z
test-workingdir                               Cluster   Complete   True      2018-04-28T20:23:49Z   2018-04-28T20:23:57Z
test-workspace-volume                         Cluster   Complete   True      2018-04-28T20:23:50Z   2018-04-28T20:24:03Z
```

Fixes: https://github.com/elafros/build/issues/121