### PR TITLE
Builds can supply & override a template's environment variables

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -61,6 +61,10 @@ type TemplateInstantiationSpec struct {
 	// Arguments, if specified, lists values that should be applied to the
 	// parameters specified by the template.
 	Arguments []ArgumentSpec `json:"arguments,omitempty"`
+
+	// Env, if specified will provide variables to all build template steps.
+	// This will override any of the template's steps environment variables
+	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
 // ArgumentSpec defines the actual values to use to populate a template's

--- a/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
@@ -189,6 +189,13 @@ func (in *BuildStatus) DeepCopyInto(out *BuildStatus) {
 	}
 	in.StartTime.DeepCopyInto(&out.StartTime)
 	in.CompletionTime.DeepCopyInto(&out.CompletionTime)
+	if in.StepStates != nil {
+		in, out := &in.StepStates, &out.StepStates
+		*out = make([]v1.ContainerState, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]BuildCondition, len(*in))
@@ -470,6 +477,13 @@ func (in *TemplateInstantiationSpec) DeepCopyInto(out *TemplateInstantiationSpec
 		in, out := &in.Arguments, &out.Arguments
 		*out = make([]ArgumentSpec, len(*in))
 		copy(*out, *in)
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/builder/common.go
+++ b/pkg/builder/common.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/elafros/build/pkg/apis/build/v1alpha1"
 )
 
@@ -76,5 +78,34 @@ func ApplyTemplate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) (*v1alpha1.B
 		}
 	}
 
+	if buildTmpl := build.Spec.Template; buildTmpl != nil && len(buildTmpl.Env) > 0 {
+		// Apply variable expansion to the build's overriden
+		// environment variables
+		for i, e := range buildTmpl.Env {
+			buildTmpl.Env[i].Value = applyReplacements(e.Value)
+		}
+
+		for i := range steps {
+			steps[i].Env = applyEnvOverride(steps[i].Env, buildTmpl.Env)
+		}
+	}
+
 	return build, nil
+}
+
+func applyEnvOverride(src, override []corev1.EnvVar) []corev1.EnvVar {
+	result := make([]corev1.EnvVar, 0, len(src)+len(override))
+	overrides := make(map[string]bool)
+
+	for _, env := range override {
+		overrides[env.Name] = true
+	}
+
+	for _, env := range src {
+		if _, present := overrides[env.Name]; !present {
+			result = append(result, env)
+		}
+	}
+
+	return append(result, override...)
 }

--- a/pkg/builder/common_test.go
+++ b/pkg/builder/common_test.go
@@ -462,6 +462,43 @@ func TestApplyTemplate(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		// A build's template initiation spec contains
+		// env vars
+		build: &v1alpha1.Build{
+			Spec: v1alpha1.BuildSpec{
+				Template: &v1alpha1.TemplateInstantiationSpec{
+					Env: []corev1.EnvVar{{
+						Name:  "SOME_ENV_VAR",
+						Value: "foo",
+					}},
+				},
+			},
+		},
+		tmpl: &v1alpha1.BuildTemplate{
+			Spec: v1alpha1.BuildTemplateSpec{
+				Steps: []corev1.Container{{
+					Name: "hello",
+				}},
+			},
+		},
+		want: &v1alpha1.Build{
+			Spec: v1alpha1.BuildSpec{
+				Steps: []corev1.Container{{
+					Name: "hello",
+					Env: []corev1.EnvVar{{
+						Name:  "SOME_ENV_VAR",
+						Value: "foo",
+					}},
+				}},
+				Template: &v1alpha1.TemplateInstantiationSpec{
+					Env: []corev1.EnvVar{{
+						Name:  "SOME_ENV_VAR",
+						Value: "foo",
+					}},
+				},
+			},
+		},
 	}} {
 		wantErr := c.want == nil
 		got, err := ApplyTemplate(c.build, c.tmpl)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -14,6 +14,7 @@ k8s_objects(
         "//tests/template-volume:test",
         "//tests/custom-source:test",
         "//tests/template-args:test",
+        "//tests/template-env-merge:test",
         "//tests/unnamed-steps:test",
         "//tests/docker-build:test",
         "//tests/gcs-archive:test",

--- a/tests/template-env-merge/BUILD
+++ b/tests/template-env-merge/BUILD
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@k8s_object//:defaults.bzl", "k8s_object")
+
+k8s_object(
+    name = "template",
+    template = "template.yaml",
+)
+
+k8s_object(
+    name = "build",
+    template = "build.yaml",
+)
+
+load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+
+k8s_objects(
+    name = "test",
+    objects = [
+        ":template",
+        ":build",
+    ],
+)

--- a/tests/template-env-merge/build.yaml
+++ b/tests/template-env-merge/build.yaml
@@ -1,0 +1,27 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: test-template-env-merge
+  labels:
+    expect: complete
+spec:
+  template:
+    name: template-env-merge
+    env:
+    - name: FOO
+      value: foo
+    - name: BAR
+      value: bar

--- a/tests/template-env-merge/template.yaml
+++ b/tests/template-env-merge/template.yaml
@@ -1,0 +1,37 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: build.dev/v1alpha1
+kind: BuildTemplate
+metadata:
+  name: template-env-merge
+spec:
+  steps:
+  # Test the environment variables are set in the build
+  # using this template
+  - name: foo
+    image: ubuntu
+    command: ['bash']
+    args: ['-c', '[[ $FOO == "foo" ]]']
+  - name: bar
+    image: ubuntu
+    command: ['bash']
+    args: ['-c', '[[ $BAR == "bar" ]]']
+  # Use the build's declared env value, overriding the template's
+  - name: foo-override
+    image: ubuntu
+    command: ['bash']
+    args: ['-c', '[[ $FOO == "foo" ]]']
+    env:
+    - name: FOO
+      value: bazzzzz


### PR DESCRIPTION
Fixes: https://github.com/elafros/build/issues/107

```release-note
A build can supply & override a template's environment variables
```
