### PR TITLE
Allow empty strings as param default values

### DIFF
--- a/pkg/apis/build/v1alpha1/build_template_types.go
+++ b/pkg/apis/build/v1alpha1/build_template_types.go
@@ -76,7 +76,7 @@ type ParameterSpec struct {
 
 	// Default, if specified, defines the default value that should be applied if
 	// the build does not specify the value for this parameter.
-	Default string `json:"default,omitempty"`
+	Default *string `json:"default,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/builder/common.go
+++ b/pkg/builder/common.go
@@ -37,8 +37,8 @@ func ApplyTemplate(u *v1alpha1.Build, tmpl *v1alpha1.BuildTemplate) (*v1alpha1.B
 	replacements := map[string]string{}
 	if tmpl != nil {
 		for _, p := range tmpl.Spec.Parameters {
-			if p.Default != "" {
-				replacements[p.Name] = p.Default
+			if p.Default != nil {
+				replacements[p.Name] = *p.Default
 			}
 		}
 	}

--- a/pkg/builder/common_test.go
+++ b/pkg/builder/common_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestApplyTemplate(t *testing.T) {
+	world := "world"
+	defaultStr := "default"
+	empty := ""
 	for i, c := range []struct {
 		build *v1alpha1.Build
 		tmpl  *v1alpha1.BuildTemplate
@@ -253,7 +256,7 @@ func TestApplyTemplate(t *testing.T) {
 				}},
 				Parameters: []v1alpha1.ParameterSpec{{
 					Name:    "FOO",
-					Default: "world",
+					Default: &world,
 				}},
 			},
 		},
@@ -268,6 +271,43 @@ func TestApplyTemplate(t *testing.T) {
 					}},
 					Command:    []string{"cmd", "world"},
 					WorkingDir: "/dir/world/bar",
+				}},
+			},
+		},
+	}, {
+		// Parameter with empty default value.
+		build: &v1alpha1.Build{
+			Spec: v1alpha1.BuildSpec{},
+		},
+		tmpl: &v1alpha1.BuildTemplate{
+			Spec: v1alpha1.BuildTemplateSpec{
+				Steps: []corev1.Container{{
+					Name: "hello ${FOO}",
+					Args: []string{"hello", "to the ${FOO}"},
+					Env: []corev1.EnvVar{{
+						Name:  "FOO",
+						Value: "is ${FOO}",
+					}},
+					Command:    []string{"cmd", "${FOO}"},
+					WorkingDir: "/dir/${FOO}/bar",
+				}},
+				Parameters: []v1alpha1.ParameterSpec{{
+					Name:    "FOO",
+					Default: &empty,
+				}},
+			},
+		},
+		want: &v1alpha1.Build{
+			Spec: v1alpha1.BuildSpec{
+				Steps: []corev1.Container{{
+					Name: "hello ",
+					Args: []string{"hello", "to the "},
+					Env: []corev1.EnvVar{{
+						Name:  "FOO",
+						Value: "is ",
+					}},
+					Command:    []string{"cmd", ""},
+					WorkingDir: "/dir//bar",
 				}},
 			},
 		},
@@ -297,7 +337,7 @@ func TestApplyTemplate(t *testing.T) {
 				}},
 				Parameters: []v1alpha1.ParameterSpec{{
 					Name:    "FOO",
-					Default: "default",
+					Default: &defaultStr,
 				}},
 			},
 		},

--- a/pkg/builder/validate.go
+++ b/pkg/builder/validate.go
@@ -102,7 +102,7 @@ func validateArguments(args []v1alpha1.ArgumentSpec, tmpl *v1alpha1.BuildTemplat
 	if tmpl != nil {
 		tmplParams := map[string]string{} // value is the param description.
 		for _, p := range tmpl.Spec.Parameters {
-			if p.Default == "" {
+			if p.Default == nil {
 				tmplParams[p.Name] = p.Description
 			}
 		}

--- a/pkg/builder/validate_test.go
+++ b/pkg/builder/validate_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestValidateBuild(t *testing.T) {
+	hasDefault := "has-default"
+	empty := ""
 	tests := []struct {
 		build  *v1alpha1.Build
 		tmpl   *v1alpha1.BuildTemplate
@@ -223,7 +225,24 @@ func TestValidateBuild(t *testing.T) {
 					Name: "foo",
 				}, {
 					Name:    "bar",
-					Default: "has-default",
+					Default: &hasDefault,
+				}},
+			},
+		},
+	}, {
+		// valid, since unsatisfied parameter has an empty default.
+		build: &v1alpha1.Build{
+			Spec: v1alpha1.BuildSpec{
+				Template: &v1alpha1.TemplateInstantiationSpec{
+					Name: "empty-default",
+				},
+			},
+		},
+		tmpl: &v1alpha1.BuildTemplate{
+			Spec: v1alpha1.BuildTemplateSpec{
+				Parameters: []v1alpha1.ParameterSpec{{
+					Name:    "foo",
+					Default: &empty,
 				}},
 			},
 		},
@@ -245,6 +264,7 @@ func TestValidateBuild(t *testing.T) {
 }
 
 func TestValidateTemplate(t *testing.T) {
+	hasDefault := "has-default"
 	tests := []struct {
 		tmpl   *v1alpha1.BuildTemplate
 		reason string // if "", expect success.
@@ -326,7 +346,7 @@ func TestValidateTemplate(t *testing.T) {
 					Name: "FOO",
 				}, {
 					Name:    "BAR",
-					Default: "has-default",
+					Default: &hasDefault,
 				}},
 			},
 		},


### PR DESCRIPTION
Ran into a case with the buildpack build template where a parameter value of empty string was valid. 

Refs elafros/build-templates#6

## Proposed Changes

  * Updated the `ParameterSpec.Default` type to be a string pointer so that empty string can be distinguished from nil.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Build template parameter default values may be empty strings
```