### PR TITLE
Make example fit the corresponding BuildTemplate

### DIFF
--- a/build-templates.md
+++ b/build-templates.md
@@ -119,6 +119,6 @@ spec:
     # Optional overrides
     - name: DIRECTORY
       value: /workspace/docker
-    - name: DOCKERFILE_PATH
+    - name: DOCKERFILE_NAME
       value: Dockerfile-17.06.1
 ```


### PR DESCRIPTION
I am guessing the example is supposed to reference parameters from the BuildTemplate and `DOCKERFILE_PATH` does not exist there, but `DOCKERFILE_NAME` does.