### PR TITLE
Rename namespace to knative-build

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -14,4 +14,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: build-system
+  name: knative-build

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: build-controller
-  namespace: build-system
+  namespace: knative-build

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -18,7 +18,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: build-controller
-    namespace: build-system
+    namespace: knative-build
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/config/400-controller-service.yaml
+++ b/config/400-controller-service.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app: build-controller
   name: build-controller
-  namespace: build-system
+  namespace: knative-build
 spec:
   ports:
   - name: metrics

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     role: build-webhook
   name: build-webhook
-  namespace: build-system
+  namespace: knative-build
 spec:
   ports:
     - port: 443

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
-  namespace: build-system
+  namespace: knative-build
 data:
   # Common configuration for all knative codebase
   zap-logger-config: |

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -15,7 +15,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: build-controller
-  namespace: build-system
+  namespace: knative-build
 spec:
   replicas: 1
   template:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: build-webhook
-  namespace: build-system
+  namespace: knative-build
 spec:
   replicas: 1
   template:

--- a/pkg/names.go
+++ b/pkg/names.go
@@ -13,4 +13,4 @@ limitations under the License.
 
 package pkg
 
-func GetBuildSystemNamespace() string { return "build-system" }
+func GetBuildSystemNamespace() string { return "knative-build" }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -43,7 +43,7 @@ const (
 var (
 	defaultOptions = ControllerOptions{
 		ServiceName:      "build-webhook",
-		ServiceNamespace: "build-system",
+		ServiceNamespace: "knative-build",
 		Port:             443,
 		SecretName:       "build-webhook-certs",
 		WebhookName:      "webhook.build.dev",


### PR DESCRIPTION
See https://github.com/knative/serving/pull/1325

**Release Note**
```release-note
Namespace is renamed from build-system to knative-build
```