### PR TITLE
Remove TemplateInstantiationSpec.Namespace

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -61,11 +61,9 @@ type BuildSpec struct {
 
 type TemplateInstantiationSpec struct {
 	// Name references the BuildTemplate resource to use.
+	//
+	// The template is assumed to exist in the Build's namespace.
 	Name string `json:"name"`
-
-	// Namespace, if specified, is the namespace of the BuildTemplate resource to
-	// use. If omitted, the build's namespace is used.
-	Namespace string `json:"namespace,omitempty"`
 
 	// Arguments, if specified, lists values that should be applied to the
 	// parameters specified by the template.

--- a/pkg/controller/build/controller.go
+++ b/pkg/controller/build/controller.go
@@ -270,16 +270,11 @@ func (c *Controller) syncHandler(key string) error {
 			// will kick in.
 			var tmpl *v1alpha1.BuildTemplate
 			if build.Spec.Template != nil {
-				tmplNS := namespace
-				if build.Spec.Template.Namespace != "" {
-					tmplNS = build.Spec.Template.Namespace
-				}
-
-				tmpl, err = c.buildTemplatesLister.BuildTemplates(tmplNS).Get(build.Spec.Template.Name)
+				tmpl, err = c.buildTemplatesLister.BuildTemplates(namespace).Get(build.Spec.Template.Name)
 				if err != nil {
 					// The BuildTemplate resource may not exist.
 					if errors.IsNotFound(err) {
-						runtime.HandleError(fmt.Errorf("build template %q in namespace %q does not exist", key, tmplNS))
+						runtime.HandleError(fmt.Errorf("build template %q in namespace %q does not exist", key, namespace))
 					}
 					return err
 				}

--- a/pkg/webhook/build.go
+++ b/pkg/webhook/build.go
@@ -54,12 +54,8 @@ func (ac *AdmissionController) validateBuild(ctx context.Context, _ *[]jsonpatch
 			return validationError("MissingTemplateName", "the build specifies a template without a name")
 		}
 
-		// Look up the template.
-		tmplNS := b.Spec.Template.Namespace
-		if tmplNS == "" {
-			tmplNS = b.Namespace
-		}
-		tmpl, err = ac.buildClient.BuildV1alpha1().BuildTemplates(tmplNS).Get(tmplName, metav1.GetOptions{})
+		// Look up the template in the Build's namespace.
+		tmpl, err = ac.buildClient.BuildV1alpha1().BuildTemplates(b.Namespace).Get(tmplName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In the future we may add a `ClusterBuildTemplate` type to allow operators to define "blessed" templates that should be used across namespaces.

For now, rather than have to make a breaking change to support that in the future, let's rip the bandaid and remove the ability to instantiate templates cross-namespace.

**Release Note**
```release-note
Removes TemplateInstantiationSpec.Namespace -- For now, BuildTemplates must be in the same namespace as the build that instantiates them
```
