### PR TITLE
Don't dump project info on E2E test failure

### DIFF
--- a/tests/e2e-tests.sh
+++ b/tests/e2e-tests.sh
@@ -67,10 +67,6 @@ function exit_if_test_failed() {
   echo "***           TEST FAILED           ***"
   echo "***    Start of information dump    ***"
   echo "***************************************"
-  if (( IS_PROW )) || [[ $PROJECT_ID != "" ]]; then
-    echo ">>> Project info:"
-    gcloud compute project-info describe
-  fi
   echo ">>> All resources:"
   kubectl get all --all-namespaces
   echo "***************************************"


### PR DESCRIPTION
The information is not relevant anymore for test debugging. Furthermore dumping the project info also leaks some of its keys.