### PR TITLE
Add missing RBAC permissions needed by webhook

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -4,7 +4,10 @@ metadata:
   name: knative-build-admin
 rules:
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "secrets", "events", "serviceaccounts"]
+    resources: ["pods", "namespaces", "secrets", "events", "serviceaccounts", "configmaps"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations"]


### PR DESCRIPTION
These permissions seem to be required for the webhook job, it fails in a crash-loop without them. We don't have any integration tests that invalid builds are rejected, so when the webhook validator isn't working, nothing catches that :-/ 

**Release Note**
```release-note
Add missing permissions to knative-build-admin ClusterRole
```

/assign @mattmoor 