### PR TITLE
[WIP] Support GitSource.Dir

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -108,6 +108,13 @@ type GitSourceSpec struct {
 	// https://git-scm.com/docs/gitrevisions#_specifying_revisions for more
 	// information.
 	Revision string `json:"revision"`
+
+	// If set, directory within the repo in which to run the build.
+	//
+	// This must be a relative path. If a step's `workingdir` is specified
+	// and is an absolute path, this value is ignored for the step's
+	// execution.
+	Dir string `json:"dir"`
 }
 
 // GCSSourceSpec describes source input to the Build in the form of an archive,

--- a/pkg/builder/cluster/convert/testdata/git-dir.yaml
+++ b/pkg/builder/cluster/convert/testdata/git-dir.yaml
@@ -1,0 +1,27 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+source:
+  git:
+    url: https://source.developers.google.com/p/a-project/r/secret-stuff
+    revision: refs/pulls/179/head
+    dir: 'srcdir'
+steps:
+- name: rel-dir
+  image: gcr.io/google-containers/busybox
+  workingdir: 'rel-stepdir'
+  args: ["echo Hello World!"]
+- name: abs-dir
+  image: gcr.io/google-containers/busybox
+  workingdir: '/abs-stepdir'
+  args: ["echo Hello World!"]


### PR DESCRIPTION
Fixes #91 

## Proposed Changes

  * Add `Dir` to `GitSourceSpec` and insert this "`srcDir`" into steps' `workingdir`s if specified.
  * Support absolute paths in steps' `workingdir`, which overrides any `srcDir` and the default `/workspace` dir.
  * Specifying a `git.dir` does _not_ perform a [narrow clone](https://github.com/git/git/blob/master/Documentation/technical/partial-clone.txt) and the entire repo's contents at the specified revision are still fetched. This simply modifies the `workingdir` to operate within the specified dir, if the step's `workingdir` is unspecified or relative.

This change currently breaks tests because of the lossy conversion when inserting `srcDir` between `/workspace` and `stepDir` -- it's impossible to know how to convert a `Build` into a `Pod` and back without knowing the borders should be between `srcDir` and `stepDir`. It's possible we'll decide we don't care about this lossy conversion, since the `Pod` will execute the same regardless, but in that case we'll need to teach tests how to accept this lossiness.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Support GitSource.Dir
```
