### PR TITLE
Make git-init reusable, and add a test

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -30,6 +30,16 @@ var (
 	revision = flag.String("revision", "", "The Git revision to make the repository HEAD")
 )
 
+func run(logger *zap.SugaredLogger, cmd string, args ...string) {
+	c := exec.Command(cmd, args...)
+	var output bytes.Buffer
+	c.Stderr = &output
+	c.Stdout = &output
+	if err := c.Run(); err != nil {
+		logger.Errorf("Error running %v %v: %v\n%v", cmd, args, err, output.String())
+	}
+}
+
 func runOrFail(logger *zap.SugaredLogger, cmd string, args ...string) {
 	c := exec.Command(cmd, args...)
 	var output bytes.Buffer
@@ -56,8 +66,8 @@ func main() {
 		logger.Fatalf("Unexpected error creating symlink: %v", err)
 	}
 
-	runOrFail(logger, "git", "init")
-	runOrFail(logger, "git", "remote", "add", "origin", *url)
+	run(logger, "git", "init")
+	run(logger, "git", "remote", "add", "origin", *url)
 	runOrFail(logger, "git", "fetch", "--depth=1", "--recurse-submodules=yes", "origin", *revision)
 	runOrFail(logger, "git", "reset", "--hard", "FETCH_HEAD")
 

--- a/tests/reuse-git-init/test.yaml
+++ b/tests/reuse-git-init/test.yaml
@@ -1,0 +1,60 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: test-reuse-git-init
+  labels:
+    expect: succeeded
+spec:
+  # First, implicitly use git-init to fetch and checkout master.
+  source:
+    git:
+      url: https://github.com/bazelbuild/rules_docker
+      revision: master
+  steps:
+  # Dump WORKSPACE from this revision.
+  - name: cat-workspace
+    image: busybox
+    args: ['cat', 'WORKSPACE']
+
+  # Then fetch and checkout a tag, and cat WORKSPACE.
+  - name: checkout-tag
+    image: github.com/knative/build/cmd/git-init
+    args:
+    - -url=https://github.com/bazelbuild/rules_docker
+    - -revision=v0.4.0
+  - name: cat-workspace-tag
+    image: busybox
+    args: ['cat', 'WORKSPACE']
+
+  # Fetch and checkout the master branch again, and cat WORKSPACE.
+  - name: checkout-branch
+    image: github.com/knative/build/cmd/git-init
+    args:
+    - -url=https://github.com/bazelbuild/rules_docker
+    - -revision=master
+  - name: cat-workspace-branch
+    image: busybox
+    args: ['cat', 'WORKSPACE']
+
+  # Fetch and checkout another repo entirely, and cat its WORKSPACE.
+  - name: checkout-other-repo
+    image: github.com/knative/build/cmd/git-init
+    args:
+    - -url=https://github.com/bazelbuild/rules_k8s
+    - -revision=master
+  - name: cat-workspace-other-repo
+    image: busybox
+    args: ['cat', 'WORKSPACE']


### PR DESCRIPTION
Related to #52 

## Proposed Changes

  * Make certain setup commands in `git-init` accepting of failure, so that it can be called multiple times in the same build.
  * Add a test that checks out a repo@revision as specified by `GitSource` (implicitly using `git-init`), then fetches another revision from the same repo, then fetches a revision from an entirely separate repo.

This opens up support for specifying that `/workspace` should be backed by a `persistentVolumeClaim`, in which case previously requested Git revisions will be present in the build's local Git repo, potentially along with previous builds' artifacts and cached dependencies. This is not supported as part of this change.

This could also enable support for _multiple_ sources per build, where each is fetched in sequence into the same `/workspace`. That would require a breaking change to the API however.

**Release Note**
```release-note
NONE
```
