### PR TITLE
Add integration test demonstrating use of PersistentVolumeClaims for inter-build caching

### DIFF
--- a/tests/cache-volume/0-pvc.yaml
+++ b/tests/cache-volume/0-pvc.yaml
@@ -1,0 +1,23 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: build-cache-claim
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/tests/cache-volume/1-test.yaml
+++ b/tests/cache-volume/1-test.yaml
@@ -1,0 +1,33 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: test-cache-volume-1
+  labels:
+    expect: succeeded
+spec:
+  steps:
+  # Populate the persistent volume with some content.
+  - name: populate-cache
+    image: ubuntu
+    command: ['bash']
+    args: ['-c', 'echo hello > /cache/foo']
+    volumeMounts:
+    - name: build-cache
+      mountPath: /cache
+  volumes:
+  - name: build-cache
+    persistentVolumeClaim:
+      claimName: build-cache-claim

--- a/tests/cache-volume/2-test.yaml
+++ b/tests/cache-volume/2-test.yaml
@@ -1,0 +1,34 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: test-cache-volume-2
+  labels:
+    expect: succeeded
+spec:
+  steps:
+  # Check that the persistent volume contains the content produced by the
+  # previous build.
+  - name: cache-populated
+    image: ubuntu
+    command: ['bash']
+    args: ['-c', '[[ $(cat /cache/foo) == "hello" ]]']
+    volumeMounts:
+    - name: build-cache
+      mountPath: /cache
+  volumes:
+  - name: build-cache
+    persistentVolumeClaim:
+      claimName: build-cache-claim


### PR DESCRIPTION
Functional example of #52 

## Proposed Changes

  * Test defines a `PersistentVolumeClaim` which is attached first to a build that populates the cache, then another build reads the cache

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
