### PR TITLE
Allow steps to mount a volume over implicit volume mounts

### DIFF
--- a/pkg/builder/cluster/convert/convert_test.go
+++ b/pkg/builder/cluster/convert/convert_test.go
@@ -42,6 +42,7 @@ func TestParsing(t *testing.T) {
 		"testdata/env.yaml",
 		"testdata/env-valuefrom.yaml",
 		"testdata/workingdir.yaml",
+		"testdata/workspace.yaml",
 		"testdata/resources.yaml",
 		"testdata/security-context.yaml",
 		"testdata/volumes.yaml",
@@ -80,34 +81,45 @@ func TestParsing(t *testing.T) {
 			},
 		}
 		cs := fakek8s.NewSimpleClientset(sa, secret)
-		j, err := FromCRD(og, cs)
+		p, err := FromCRD(og, cs)
 		if err != nil {
 			t.Errorf("Unable to convert %q from CRD: %v", in, err)
 			continue
 		}
 
 		// Verify that secrets are loaded correctly.
-		if j.Spec.ServiceAccountName != "" {
-			for _, vol := range j.Spec.Volumes {
+		if p.Spec.ServiceAccountName != "" {
+			for _, vol := range p.Spec.Volumes {
 				if vol.Name == "secret-volume-multi-creds" {
 					if vol.Secret.SecretName != "multi-creds" {
-						t.Errorf("Expected multi-creds to be mounted in Pod %v", j.Spec)
+						t.Errorf("Expected multi-creds to be mounted in Pod %v", p.Spec)
 					}
 				}
 			}
 			expected := map[string]int{"https://us.gcr.io": 1, "https://docker.io": 1, "github.com": 1, "gitlab.com": 1}
-			for _, a := range j.Spec.InitContainers[0].Args {
+			for _, a := range p.Spec.InitContainers[0].Args {
 				expected[a] -= 1
 			}
 			for k, c := range expected {
 				if c > 0 {
-					t.Errorf("Expected arg related to %s in args, got %v", k, j.Spec.InitContainers[0].Args)
+					t.Errorf("Expected arg related to %s in args, got %v", k, p.Spec.InitContainers[0].Args)
 				}
 			}
 		}
+
+		// Verify that volumeMounts are mounted at a unique path.
+		for i, s := range p.Spec.InitContainers {
+			seen := map[string]struct{}{}
+			for _, vm := range s.VolumeMounts {
+				if _, found := seen[vm.MountPath]; found {
+					t.Errorf("Step %d had duplicate volumeMount path %q", i, vm.MountPath)
+				}
+				seen[vm.MountPath] = struct{}{}
+			}
+		}
+
 		// Verify that reverse transformation works.
-		
-		b, err := ToCRD(j)
+		b, err := ToCRD(p)
 		if err != nil {
 			t.Errorf("Unable to convert %q to CRD: %v", in, err)
 			continue

--- a/pkg/builder/cluster/convert/testdata/workspace.yaml
+++ b/pkg/builder/cluster/convert/testdata/workspace.yaml
@@ -11,31 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: build.knative.dev/v1alpha1
-kind: Build
-metadata:
-  name: test-workspace-volume
-  labels:
-    expect: succeeded
-spec:
-  steps:
-  - name: write
-    image: ubuntu
-    command: ['bash']
-    args: ['-c', 'echo some stuff > /workspace/stuff']
-  - name: read
-    image: ubuntu
-    args: ['cat', '/workspace/stuff']
-
-  - name: override-workspace
-    image: ubuntu
-    command: ['bash']
-    # /workspace/stuff *doesn't* exist.
-    args: ['-c', '[[ ! -f /workspace/stuff ]]']
-    volumeMounts:
-    - name: empty
-      mountPath: /workspace
-
-  volumes:
+steps:
+- name: override-workspace
+  image: busybox
+  args: ["echo Hello"]
+  volumeMounts:
   - name: empty
-    emptyDir: {}
+    mountPath: /workspace
+
+- name: override-home
+  image: busybox
+  args: ["echo Hello"]
+  volumeMounts:
+  - name: empty
+    mountPath: /builder/home

--- a/tests/home-volume/test.yaml
+++ b/tests/home-volume/test.yaml
@@ -20,10 +20,22 @@ metadata:
 spec:
   steps:
   - name: write
-    image: ubuntu:latest
-    command: ["/bin/bash"]
-    args: ["-c", "echo some stuff > /builder/home/stuff"]
+    image: ubuntu
+    command: ['bash']
+    args: ['-c', 'echo some stuff > /builder/home/stuff']
   - name: read
-    image: ubuntu:latest
-    command: ["/bin/bash"]
-    args: ["-c", "cat /builder/home/stuff"]
+    image: ubuntu
+    args: ['cat', '/builder/home/stuff']
+
+  - name: override-homevol
+    image: ubuntu
+    command: ['bash']
+    # /builder/home/stuff *doesn't* exist.
+    args: ['-c', '[[ ! -f /builder/home/stuff ]]']
+    volumeMounts:
+    - name: empty
+      mountPath: /builder/home
+
+  volumes:
+  - name: empty
+    emptyDir: {}


### PR DESCRIPTION
Related to #52 

## Proposed Changes

  * Allow steps to specify `volumeMounts` with a `mountPath` that conflicts with the implicit volume mounts we typically attach (`/workspace` and `/builder/home`).
  * If such a `volumeMount` is specified, the implicit volume mount is not attached.
  * Add unit tests and integration tests

**Release Note**
```release-note
NONE
```
