### PR TITLE
Specify knative category in CRDs

### DIFF
--- a/config/300-build.yaml
+++ b/config/300-build.yaml
@@ -21,4 +21,7 @@ spec:
   names:
     kind: Build
     plural: builds
+    categories:
+    - all
+    - knative
   scope: Namespaced

--- a/config/300-buildtemplate.yaml
+++ b/config/300-buildtemplate.yaml
@@ -21,4 +21,7 @@ spec:
   names:
     kind: BuildTemplate
     plural: buildtemplates
+    categories:
+    - all
+    - knative
   scope: Namespaced


### PR DESCRIPTION
Inspired by https://github.com/knative/eventing/pull/234

This enables builds to show up in the output of `kubectl get knative`, which will also show eventing and eventually serving resources.

**Release Note**
```release-note
NONE
```

/assign mattmoor