### PR TITLE
Use release.sh helper from prow-tests image

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -14,37 +14,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Load github.com/knative/test-infra/images/prow-tests/scripts/release.sh
+[ -f /workspace/release.sh ] \
+  && source /workspace/release.sh \
+  || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat release.sh')"
+[ -v KNATIVE_TEST_INFRA ] || exit 1
+
+# Set default GCS/GCR
+: ${BUILD_RELEASE_GCS:="build-crd"}
+: ${BUILD_RELEASE_GCR:="gcr.io/build-crd"}
+readonly BUILD_RELEASE_GCS
+readonly BUILD_RELEASE_GCR
+
+# Local generated yaml file
+readonly OUTPUT_YAML=release.yaml
+
+# Script entry point
+
+parse_flags $@
+
 set -o errexit
 set -o pipefail
 
-source "$(dirname $(readlink -f ${BASH_SOURCE}))/../test/library.sh"
+run_validation_tests ./test/presubmit-tests.sh
 
-function cleanup() {
-  restore_override_vars
-}
+banner "Building the release"
 
-cd ${BUILD_ROOT_DIR}
-trap cleanup EXIT
+# Set the repository
+export KO_DOCKER_REPO=${BUILD_RELEASE_GCR}
+# Build should not try to deploy anything, use a bogus value for cluster.
+export K8S_CLUSTER_OVERRIDE=CLUSTER_NOT_SET
+export K8S_USER_OVERRIDE=USER_NOT_SET
+export DOCKER_REPO_OVERRIDE=DOCKER_NOT_SET
 
-echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
-echo "@@@@ RUNNING RELEASE VALIDATION TESTS @@@@"
-echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
-
-# Run tests.
-./test/presubmit-tests.sh
-
-echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
-echo "@@@@     BUILDING THE RELEASE    @@@@"
-echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
-
-# Set the repository to the official one:
-export KO_DOCKER_REPO=gcr.io/build-crd
+if (( PUBLISH_RELEASE )); then
+  echo "- Destination GCR: ${BUILD_RELEASE_GCR}"
+  echo "- Destination GCS: ${BUILD_RELEASE_GCS}"
+fi
 
 echo "Building build-crd"
-ko resolve -P -f config/ > release.yaml
+ko resolve ${KO_FLAGS} -P -f config/ > ${OUTPUT_YAML}
+tag_images_in_yaml ${OUTPUT_YAML} ${BUILD_RELEASE_GCR} ${TAG}
 
-echo "Publishing release.yaml"
-gsutil cp release.yaml gs://build-crd/latest/release.yaml
+echo "New release built successfully"
+
+if (( ! PUBLISH_RELEASE )); then
+ exit 0
+fi
+
+echo "Publishing ${OUTPUT_YAML}"
+publish_yaml ${OUTPUT_YAML} ${BUILD_RELEASE_GCS} ${TAG}
 
 echo "New release published successfully"
 


### PR DESCRIPTION
We're consolidating the test infrastructure into a single place, so all repos get the same fixes, updates and new features.

`release.sh` helper is implemented by knative/test-infra#14

**Bonus!** Now build-crd release script has the following features, just like serving and eventing:
* setting custom GCR/GCS buckets through environment variables
* release tagging
* test skipping
* local build

Fixes #267