### PR TITLE
Use e2e-tests.sh helper from prow-tests image

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -56,6 +56,7 @@ set -o errexit
 set -o pipefail
 
 header "Building and starting the controller"
+export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 ko apply -f config/ || fail_test
 
 # Handle test failures ourselves, so we can dump useful info.


### PR DESCRIPTION
We're consolidating the test infrastructure into a single place, so all repos get the same fixes, updates and new features.

`e2e-tests.sh` helper was implemented by knative/test-infra#17