### PR TITLE
Move build releases to knative-releases GCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ block for CI/CD in [the future](./roadmap-2018.md)
 
 You can install the latest release of the Build CRD by running:
 ```shell
-kubectl create -f https://storage.googleapis.com/build-crd/latest/release.yaml
+kubectl create -f https://storage.googleapis.com/knative-releases/latest/release-build.yaml
 ```
 
 Your account must have the `cluster-admin` role in order to do this. If your

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,13 +21,13 @@
 [ -v KNATIVE_TEST_INFRA ] || exit 1
 
 # Set default GCS/GCR
-: ${BUILD_RELEASE_GCS:="build-crd"}
-: ${BUILD_RELEASE_GCR:="gcr.io/build-crd"}
+: ${BUILD_RELEASE_GCS:="knative-releases"}
+: ${BUILD_RELEASE_GCR:="gcr.io/knative-releases"}
 readonly BUILD_RELEASE_GCS
 readonly BUILD_RELEASE_GCR
 
 # Local generated yaml file
-readonly OUTPUT_YAML=release.yaml
+readonly OUTPUT_YAML=release-build.yaml
 
 # Script entry point
 


### PR DESCRIPTION
Now all Knative releases (serving, eventing, build) are in one place.