### PR TITLE
Show additional build state info in CLI

### DIFF
--- a/config/300-build.yaml
+++ b/config/300-build.yaml
@@ -25,3 +25,10 @@ spec:
     - all
     - knative
   scope: Namespaced
+  additionalPrinterColumns:
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  - name: Completed
+    type: date
+    JSONPath: .status.completionTime

--- a/config/300-buildtemplate.yaml
+++ b/config/300-buildtemplate.yaml
@@ -25,3 +25,10 @@ spec:
     - all
     - knative
   scope: Namespaced
+  additionalPrinterColumns:
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  - name: Completed
+    type: date
+    JSONPath: .status.completionTime

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -180,6 +180,8 @@ type BuildStatus struct {
 	StepStates []corev1.ContainerState `json:"stepStates,omitEmpty"`
 	// Conditions describes the set of conditions of this build.
 	Conditions []BuildCondition `json:"conditions,omitempty"`
+
+	StepsCompleted []string `json:"stepsCompleted"`
 }
 
 // ClusterSpec provides information about the on-cluster build, if applicable.

--- a/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
@@ -208,6 +208,11 @@ func (in *BuildStatus) DeepCopyInto(out *BuildStatus) {
 		*out = make([]BuildCondition, len(*in))
 		copy(*out, *in)
 	}
+	if in.StepsCompleted != nil {
+		in, out := &in.StepsCompleted, &out.StepsCompleted
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Add 'completed' column to 'get' cli to clearly indicate whether a build
has completed. Also add 'completed steps' field which can be used to
more easily determine current build status.

Fixes #233

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note 
Add completed column and stepsCompleted to CLI
```