### PR TITLE
Minor quality of life improvements

### DIFF
--- a/pkg/builder/cluster/convert/convert.go
+++ b/pkg/builder/cluster/convert/convert.go
@@ -65,7 +65,7 @@ var (
 		Name:    "nop",
 		Image:   "busybox",
 		Command: []string{"/bin/echo"},
-		Args:    []string{"Nothing to push"},
+		Args:    []string{"Build successful"},
 	}
 )
 
@@ -87,7 +87,7 @@ const (
 	initContainerPrefix        = "build-step-"
 	unnamedInitContainerPrefix = "build-step-unnamed-"
 	// A label with the following is added to the pod to identify the pods belonging to a build.
-	buildNameLabelKey = "build-name"
+	buildNameLabelKey = "build.knative.dev/buildName"
 	// Name of the credential initialization container.
 	credsInit = "credential-initializer"
 	// Names for source containers.


### PR DESCRIPTION
Fixes #295 

## Proposed Changes

  * Label build pods with `build.knative.dev/buildName` instead of un-namespaced `build-name`
  * Log `Build successful` when build pod init containers are done, instead of the misleading and anachronistic `Nothing to push`

<!--
/assign mattmoor
-->

**Release Note**
```release-note
Build pods labels are namespaced
```
