### PR TITLE
Make verify-codegen.sh compatible with OS X

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
 
-readonly TMP_DIFFROOT="$(mktemp -d -p ${REPO_ROOT_DIR})"
+readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
 
 cleanup() {
   rm -rf "${TMP_DIFFROOT}"


### PR DESCRIPTION
OS X's `mktemp` has no `-p` flag.