### PR TITLE
Dockerfile for new minimal base image based on alpine

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:latest
+  
+RUN apk add --update git openssh-client
+


### PR DESCRIPTION
Related to https://github.com/knative/build/issues/179

## Proposed Changes

  * Add a Dockerfile to generate a minimal base image to be used by build
  * Once this image is published, the `.ko.yaml` file should be updated to point to it

**Release Note**
```
Base image used by build now based on alpine to make downloads faster
```
