### PR TITLE
Build smaller base image in release.sh

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,3 +1,3 @@
 baseImageOverrides:
-  github.com/knative/build/cmd/creds-init: gcr.io/cloud-builders/gcloud:latest
-  github.com/knative/build/cmd/git-init: gcr.io/cloud-builders/gcloud:latest
+  github.com/knative/build/cmd/creds-init: gcr.io/knative-releases/build-base:latest
+  github.com/knative/build/cmd/git-init: gcr.io/knative-releases/build-base:latest

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -36,6 +36,10 @@ run_validation_tests ./test/presubmit-tests.sh
 
 banner "Building the release"
 
+# Build and push the base image for creds-init and git images.
+docker build -t $BUILD_RELEASE_GCR/build-base -f images/Dockerfile images/
+docker push $BUILD_RELEASE_GCR/build-base
+
 # Set the repository
 export KO_DOCKER_REPO=${BUILD_RELEASE_GCR}
 # Build should not try to deploy anything, use a bogus value for cluster.


### PR DESCRIPTION
Fixes #179

## Proposed Changes

  * Build the common base image added in #317 during `hack/release.sh` (and build it once manually just now)
  * Specify this base image in `.ko.yaml` so `git-init` and `creds-init` images are built atop it.

**Release Note**
```release-note
NONE
```

/cc @pivotal-nader-ziada 
/assign mattmoor