### PR TITLE
enqueue again after the build timeout

### DIFF
--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -81,25 +81,27 @@ func IsDone(status *v1alpha1.BuildStatus) bool {
 // IsTimeout returns true if the build's execution time is greater than
 // specified build spec timeout.
 func IsTimeout(status *v1alpha1.BuildStatus, buildTimeout *metav1.Duration) bool {
-	var timeout time.Duration
-	var defaultTimeout = 10 * time.Minute
-
 	if status == nil {
 		return false
-	}
-
-	if buildTimeout == nil {
-		// Set default timeout to 10 minute if build timeout is not set
-		timeout = defaultTimeout
-	} else {
-		timeout = buildTimeout.Duration
 	}
 
 	// If build has not started timeout, startTime should be zero.
 	if status.StartTime.Time.IsZero() {
 		return false
 	}
-	return time.Since(status.StartTime.Time).Seconds() > timeout.Seconds()
+
+	timeout := GetBuildTimeoutDuration(buildTimeout)
+	return time.Since(status.StartTime.Time) > timeout
+}
+
+// GetBuildTimeoutDuration returns the build's timeout time
+// and it will return the default timeout time 10 minute if the build timeout is not set
+func GetBuildTimeoutDuration(buildTimeout *metav1.Duration) time.Duration {
+	if buildTimeout == nil {
+		// Set default timeout to 10 minute if build timeout is not set
+		return 10 * time.Minute
+	}
+	return buildTimeout.Duration
 }
 
 // ErrorMessage returns the error message from the status.


### PR DESCRIPTION
Fixes #332 

## Proposed Changes

  * enqueue a build item again after it timeout

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
enqueue a build item again after it timeout
```
