### PR TITLE
Emit metric to track null build latency

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -55,7 +55,9 @@ kubectl delete --ignore-not-found=true buildtemplates --all
 failed=0
 
 header "Running Go e2e tests"
-report_go_test -tags e2e ./test/e2e/... -count=1 || failed=1
+options=""
+(( EMIT_METRICS )) && options="-emitmetrics"
+report_go_test -tags e2e ./test/e2e/... -count=1 ${options} || failed=1
 
 header "Running YAML e2e tests"
 if ! run_yaml_tests; then

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -21,7 +21,6 @@ package e2e
 import (
 	"context"
 	"flag"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -47,11 +46,6 @@ func TestMain(m *testing.M) {
 		logging.InitializeMetricExporter()
 	}
 
-	clients, err := newClients(test.Flags.Kubeconfig, test.Flags.Cluster, buildTestNamespace)
-	if err != nil {
-		log.Fatalf("newClients: %v", err)
-	}
-
 	clients := setup(logger)
 	test.CleanupOnInterrupt(func() { teardownNamespace(clients, logger) }, logger)
 	var code int
@@ -71,11 +65,6 @@ func TestMain(m *testing.M) {
 func TestSimpleBuild(t *testing.T) {
 	logger := logging.GetContextLogger("TestSimpleBuild")
 	clients := buildClients(logger)
-
-	// Emit a metric for null-build latency (i.e., time to schedule and execute
-	// and finish watching a build).
-	_, span := trace.StartSpan(context.Background(), "NullBuildLatency")
-	defer span.End()
 
 	// Emit a metric for null-build latency (i.e., time to schedule and execute
 	// and finish watching a build).

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -21,6 +21,7 @@ package e2e
 import (
 	"context"
 	"flag"
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -41,6 +42,15 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	logging.InitializeLogger(test.Flags.LogVerbose)
 	logger := logging.GetContextLogger("TestSetup")
+	flag.Set("alsologtostderr", "true")
+	if test.Flags.EmitMetrics {
+		logging.InitializeMetricExporter()
+	}
+
+	clients, err := newClients(test.Flags.Kubeconfig, test.Flags.Cluster, buildTestNamespace)
+	if err != nil {
+		log.Fatalf("newClients: %v", err)
+	}
 
 	clients := setup(logger)
 	test.CleanupOnInterrupt(func() { teardownNamespace(clients, logger) }, logger)

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -67,6 +67,11 @@ func TestSimpleBuild(t *testing.T) {
 	_, span := trace.StartSpan(context.Background(), "NullBuildLatency")
 	defer span.End()
 
+	// Emit a metric for null-build latency (i.e., time to schedule and execute
+	// and finish watching a build).
+	_, span := trace.StartSpan(context.Background(), "NullBuildLatency")
+	defer span.End()
+
 	buildName := "simple-build"
 
 	test.CleanupOnInterrupt(func() { teardownBuild(clients, logger, buildName) }, logger)

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"flag"
 	"os"
 	"testing"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
+	"go.opencensus.io/trace"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -59,6 +61,12 @@ func TestMain(m *testing.M) {
 func TestSimpleBuild(t *testing.T) {
 	logger := logging.GetContextLogger("TestSimpleBuild")
 	clients := buildClients(logger)
+
+	// Emit a metric for null-build latency (i.e., time to schedule and execute
+	// and finish watching a build).
+	_, span := trace.StartSpan(context.Background(), "NullBuildLatency")
+	defer span.End()
+
 	buildName := "simple-build"
 
 	test.CleanupOnInterrupt(func() { teardownBuild(clients, logger, buildName) }, logger)


### PR DESCRIPTION
## Proposed Changes

  * Optionally emit a metric that tracks how long a simple no-op build takes to schedule, execute and finish watching. This should help us identify serious latency regressions that might affect all builds.

## TODO

I'm pretty sure there's more I need to do here, to get these metrics displayed at http://testgrid.knative.dev/knative-build -- like [knative/serving has](http://testgrid-dot-knative-tests.appspot.com/knative-serving#latency). I'm not sure if that change happens in this repo somehow/somewhere, or in whatever config powers testgrid. /cc @jessiezcc 

**Release Note**
```release-note
NONE
```

/hold