### PR TITLE
Trim StepStates for implicit steps

### DIFF
--- a/pkg/builder/cluster/builder.go
+++ b/pkg/builder/cluster/builder.go
@@ -46,8 +46,7 @@ func (op *operation) Name() string {
 	return op.name
 }
 
-func (op *operation) Checkpoint(build *v1alpha1.Build) error {
-	status := build.Status
+func (op *operation) Checkpoint(build *v1alpha1.Build, status *v1alpha1.BuildStatus) error {
 	status.Builder = v1alpha1.ClusterBuildProvider
 	if status.Cluster == nil {
 		status.Cluster = &v1alpha1.ClusterSpec{}
@@ -65,6 +64,9 @@ func (op *operation) Checkpoint(build *v1alpha1.Build) error {
 		// If the build specifies source, skip another container status, which
 		// is the source-fetching container.
 		skip++
+	}
+	if skip > len(op.statuses) {
+		skip = 0
 	}
 
 	for _, s := range op.statuses[skip:] {

--- a/pkg/builder/cluster/builder_test.go
+++ b/pkg/builder/cluster/builder_test.go
@@ -60,8 +60,11 @@ func TestBasicFlow(t *testing.T) {
 		t.Fatalf("Unexpected error executing builder.Build: %v", err)
 	}
 
-	var bs v1alpha1.BuildStatus
-	if err := op.Checkpoint(&bs); err != nil {
+	build := &v1alpha1.Build{
+		Status: v1alpha1.BuildStatus{},
+	}
+	bs := build.Status
+	if err := op.Checkpoint(build); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
 	if buildercommon.IsDone(&bs) {
@@ -163,8 +166,11 @@ func TestNonFinalUpdateFlow(t *testing.T) {
 		t.Fatalf("Unexpected error executing builder.Build: %v", err)
 	}
 
-	var bs v1alpha1.BuildStatus
-	if err := op.Checkpoint(&bs); err != nil {
+	build := &v1alpha1.Build{
+		Status: v1alpha1.BuildStatus{},
+	}
+	bs := build.Status
+	if err := op.Checkpoint(build); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
 	if buildercommon.IsDone(&bs) {
@@ -260,8 +266,11 @@ func TestFailureFlow(t *testing.T) {
 		t.Fatalf("Unexpected error executing builder.Build: %v", err)
 	}
 
-	var bs v1alpha1.BuildStatus
-	if err := op.Checkpoint(&bs); err != nil {
+	build := &v1alpha1.Build{
+		Status: v1alpha1.BuildStatus{},
+	}
+	bs := build.Status
+	if err := op.Checkpoint(build); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
 	if buildercommon.IsDone(&bs) {
@@ -365,8 +374,11 @@ func TestPodPendingFlow(t *testing.T) {
 		t.Fatalf("Unexpected error executing builder.Build: %v", err)
 	}
 
-	var bs v1alpha1.BuildStatus
-	if err := op.Checkpoint(&bs); err != nil {
+	build := &v1alpha1.Build{
+		Status: v1alpha1.BuildStatus{},
+	}
+	bs := build.Status
+	if err := op.Checkpoint(build); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
 	if buildercommon.IsDone(&bs) {
@@ -479,8 +491,11 @@ func TestStepFailureFlow(t *testing.T) {
 		t.Fatalf("Unexpected error executing builder.Build: %v", err)
 	}
 
-	var bs v1alpha1.BuildStatus
-	if err := op.Checkpoint(&bs); err != nil {
+	build := &v1alpha1.Build{
+		Status: v1alpha1.BuildStatus{},
+	}
+	bs := build.Status
+	if err := op.Checkpoint(build); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
 	if buildercommon.IsDone(&bs) {

--- a/pkg/builder/cluster/builder_test.go
+++ b/pkg/builder/cluster/builder_test.go
@@ -63,23 +63,22 @@ func TestBasicFlow(t *testing.T) {
 	build := &v1alpha1.Build{
 		Status: v1alpha1.BuildStatus{},
 	}
-	bs := build.Status
-	if err := op.Checkpoint(build); err != nil {
+	if err := op.Checkpoint(build, &build.Status); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
-	if buildercommon.IsDone(&bs) {
-		t.Errorf("IsDone(%v); wanted not done, got done.", bs)
+	if buildercommon.IsDone(&build.Status) {
+		t.Errorf("IsDone(%v); wanted not done, got done.", build.Status)
 	}
-	if bs.CreationTime.IsZero() {
-		t.Errorf("bs.CreationTime; want zero, got %v", bs.CreationTime)
+	if build.Status.CreationTime.IsZero() {
+		t.Errorf("build.Status.CreationTime; want zero, got %v", build.Status.CreationTime)
 	}
-	if !bs.CompletionTime.IsZero() {
-		t.Errorf("bs.CompletionTime; want zero, got %v", bs.CompletionTime)
+	if !build.Status.CompletionTime.IsZero() {
+		t.Errorf("build.Status.CompletionTime; want zero, got %v", build.Status.CompletionTime)
 	}
-	if !bs.StartTime.IsZero() {
-		t.Errorf("bs.StartTime; want non-zero, got %v", bs.StartTime)
+	if !build.Status.StartTime.IsZero() {
+		t.Errorf("build.Status.StartTime; want non-zero, got %v", build.Status.StartTime)
 	}
-	op, err = builder.OperationFromStatus(&bs)
+	op, err = builder.OperationFromStatus(&build.Status)
 	if err != nil {
 		t.Fatalf("Unexpected error executing OperationFromStatus: %v", err)
 	}
@@ -169,23 +168,22 @@ func TestNonFinalUpdateFlow(t *testing.T) {
 	build := &v1alpha1.Build{
 		Status: v1alpha1.BuildStatus{},
 	}
-	bs := build.Status
-	if err := op.Checkpoint(build); err != nil {
+	if err := op.Checkpoint(build, &build.Status); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
-	if buildercommon.IsDone(&bs) {
-		t.Errorf("IsDone(%v); wanted not done, got done.", bs)
+	if buildercommon.IsDone(&build.Status) {
+		t.Errorf("IsDone(%v); wanted not done, got done.", build.Status)
 	}
-	if bs.CreationTime.IsZero() {
-		t.Errorf("bs.CreationTime; want zero, got %v", bs.CreationTime)
+	if build.Status.CreationTime.IsZero() {
+		t.Errorf("build.Status.CreationTime; want zero, got %v", build.Status.CreationTime)
 	}
-	if !bs.CompletionTime.IsZero() {
-		t.Errorf("bs.CompletionTime; want zero, got %v", bs.CompletionTime)
+	if !build.Status.CompletionTime.IsZero() {
+		t.Errorf("build.Status.CompletionTime; want zero, got %v", build.Status.CompletionTime)
 	}
-	if !bs.StartTime.IsZero() {
-		t.Errorf("bs.StartTime; want non-zero, got %v", bs.StartTime)
+	if !build.Status.StartTime.IsZero() {
+		t.Errorf("build.Status.StartTime; want non-zero, got %v", build.Status.StartTime)
 	}
-	op, err = builder.OperationFromStatus(&bs)
+	op, err = builder.OperationFromStatus(&build.Status)
 	if err != nil {
 		t.Fatalf("Unexpected error executing OperationFromStatus: %v", err)
 	}
@@ -269,23 +267,22 @@ func TestFailureFlow(t *testing.T) {
 	build := &v1alpha1.Build{
 		Status: v1alpha1.BuildStatus{},
 	}
-	bs := build.Status
-	if err := op.Checkpoint(build); err != nil {
+	if err := op.Checkpoint(build, &build.Status); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
-	if buildercommon.IsDone(&bs) {
-		t.Errorf("IsDone(%v); wanted not done, got done.", bs)
+	if buildercommon.IsDone(&build.Status) {
+		t.Errorf("IsDone(%v); wanted not done, got done.", build.Status)
 	}
-	if bs.CreationTime.IsZero() {
-		t.Errorf("bs.CreationTime; want zero, got %v", bs.CreationTime)
+	if build.Status.CreationTime.IsZero() {
+		t.Errorf("build.Status.CreationTime; want zero, got %v", build.Status.CreationTime)
 	}
-	if !bs.CompletionTime.IsZero() {
-		t.Errorf("bs.CompletionTime; want zero, got %v", bs.CompletionTime)
+	if !build.Status.CompletionTime.IsZero() {
+		t.Errorf("build.Status.CompletionTime; want zero, got %v", build.Status.CompletionTime)
 	}
-	if !bs.StartTime.IsZero() {
-		t.Errorf("bs.StartTime; want non-zero, got %v", bs.StartTime)
+	if !build.Status.StartTime.IsZero() {
+		t.Errorf("build.Status.StartTime; want non-zero, got %v", build.Status.StartTime)
 	}
-	op, err = builder.OperationFromStatus(&bs)
+	op, err = builder.OperationFromStatus(&build.Status)
 	if err != nil {
 		t.Fatalf("Unexpected error executing OperationFromStatus: %v", err)
 	}
@@ -377,23 +374,22 @@ func TestPodPendingFlow(t *testing.T) {
 	build := &v1alpha1.Build{
 		Status: v1alpha1.BuildStatus{},
 	}
-	bs := build.Status
-	if err := op.Checkpoint(build); err != nil {
+	if err := op.Checkpoint(build, &build.Status); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
-	if buildercommon.IsDone(&bs) {
-		t.Errorf("IsDone(%v); wanted not done, got done.", bs)
+	if buildercommon.IsDone(&build.Status) {
+		t.Errorf("IsDone(%v); wanted not done, got done.", build.Status)
 	}
-	if bs.CreationTime.IsZero() {
-		t.Errorf("bs.CreationTime; want zero, got %v", bs.CreationTime)
+	if build.Status.CreationTime.IsZero() {
+		t.Errorf("build.Status.CreationTime; want zero, got %v", build.Status.CreationTime)
 	}
-	if !bs.CompletionTime.IsZero() {
-		t.Errorf("bs.CompletionTime; want zero, got %v", bs.CompletionTime)
+	if !build.Status.CompletionTime.IsZero() {
+		t.Errorf("build.Status.CompletionTime; want zero, got %v", build.Status.CompletionTime)
 	}
-	if !bs.StartTime.IsZero() {
-		t.Errorf("bs.StartTime; want non-zero, got %v", bs.StartTime)
+	if !build.Status.StartTime.IsZero() {
+		t.Errorf("build.Status.StartTime; want non-zero, got %v", build.Status.StartTime)
 	}
-	op, err = builder.OperationFromStatus(&bs)
+	op, err = builder.OperationFromStatus(&build.Status)
 	if err != nil {
 		t.Fatalf("Unexpected error executing OperationFromStatus: %v", err)
 	}
@@ -494,23 +490,22 @@ func TestStepFailureFlow(t *testing.T) {
 	build := &v1alpha1.Build{
 		Status: v1alpha1.BuildStatus{},
 	}
-	bs := build.Status
-	if err := op.Checkpoint(build); err != nil {
+	if err := op.Checkpoint(build, &build.Status); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
-	if buildercommon.IsDone(&bs) {
-		t.Errorf("IsDone(%v); wanted not done, got done.", bs)
+	if buildercommon.IsDone(&build.Status) {
+		t.Errorf("IsDone(%v); wanted not done, got done.", build.Status)
 	}
-	if bs.CreationTime.IsZero() {
-		t.Errorf("bs.CreationTime; want zero, got %v", bs.CreationTime)
+	if build.Status.CreationTime.IsZero() {
+		t.Errorf("build.Status.CreationTime; want zero, got %v", build.Status.CreationTime)
 	}
-	if !bs.StartTime.IsZero() {
-		t.Errorf("bs.StartTime; want non-zero, got %v", bs.StartTime)
+	if !build.Status.StartTime.IsZero() {
+		t.Errorf("build.Status.StartTime; want non-zero, got %v", build.Status.StartTime)
 	}
-	if !bs.CompletionTime.IsZero() {
-		t.Errorf("bs.CompletionTime; want zero, got %v", bs.CompletionTime)
+	if !build.Status.CompletionTime.IsZero() {
+		t.Errorf("build.Status.CompletionTime; want zero, got %v", build.Status.CompletionTime)
 	}
-	op, err = builder.OperationFromStatus(&bs)
+	op, err = builder.OperationFromStatus(&build.Status)
 	if err != nil {
 		t.Fatalf("Unexpected error executing OperationFromStatus: %v", err)
 	}

--- a/pkg/builder/cluster/convert/convert_test.go
+++ b/pkg/builder/cluster/convert/convert_test.go
@@ -17,10 +17,8 @@ limitations under the License.
 package convert
 
 import (
-	"encoding/json"
 	"testing"
 
-	"github.com/sergi/go-diff/diffmatchpatch"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
@@ -123,7 +121,7 @@ func TestRoundtrip(t *testing.T) {
 				t.Fatalf("Unable to convert %q to CRD: %v", in, err)
 			}
 
-			if d := diff(og, b); d != "" {
+			if d := buildtest.JSONDiff(og, b); d != "" {
 				t.Errorf("Diff:\n%s", d)
 			}
 		})
@@ -348,29 +346,9 @@ func TestFromCRD(t *testing.T) {
 				t.Fatalf("FromCRD: %v", err)
 			}
 
-			if d := diff(got.Spec, c.want); d != "" {
+			if d := buildtest.JSONDiff(got.Spec, c.want); d != "" {
 				t.Errorf("Diff:\n%s", d)
 			}
 		})
 	}
-}
-
-func diff(l, r interface{}) string {
-	lb, err := json.MarshalIndent(l, "", " ")
-	if err != nil {
-		panic(err.Error())
-	}
-	rb, err := json.MarshalIndent(r, "", " ")
-	if err != nil {
-		panic(err.Error())
-	}
-
-	dmp := diffmatchpatch.New()
-	diffs := dmp.DiffMain(string(lb), string(rb), true)
-	for _, d := range diffs {
-		if d.Type != diffmatchpatch.DiffEqual {
-			return dmp.DiffPrettyText(diffs)
-		}
-	}
-	return ""
 }

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -29,9 +29,9 @@ type Operation interface {
 	// Name provides the unique name for this operation, see OperationFromStatus.
 	Name() string
 
-	// Checkpoint augments the provided BuildStatus with sufficient state to be restored
-	// by OperationFromStatus on an appropriate BuildProvider.
-	Checkpoint(*v1alpha1.BuildStatus) error
+	// Checkpoint augments the provided Build's Status with sufficient state to
+	// be restored by OperationFromStatus on an appropriate BuildProvider.
+	Checkpoint(*v1alpha1.Build) error
 
 	// Wait blocks until the Operation completes, returning either a status for the build or an error.
 	// TODO(mattmoor): This probably shouldn't be BuildStatus, but some sort of smaller-scope thing.

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -29,9 +29,11 @@ type Operation interface {
 	// Name provides the unique name for this operation, see OperationFromStatus.
 	Name() string
 
-	// Checkpoint augments the provided Build's Status with sufficient state to
-	// be restored by OperationFromStatus on an appropriate BuildProvider.
-	Checkpoint(*v1alpha1.Build) error
+	// Checkpoint augments the provided BuildStatus with sufficient state to be
+	// restored by OperationFromStatus on an appropriate BuildProvider.
+	//
+	// This takes into account necessary information about the provided Build.
+	Checkpoint(*v1alpha1.Build, *v1alpha1.BuildStatus) error
 
 	// Wait blocks until the Operation completes, returning either a status for the build or an error.
 	// TODO(mattmoor): This probably shouldn't be BuildStatus, but some sort of smaller-scope thing.

--- a/pkg/builder/nop/builder.go
+++ b/pkg/builder/nop/builder.go
@@ -40,8 +40,7 @@ type operation struct {
 
 func (nb *operation) Name() string { return operationName }
 
-func (nb *operation) Checkpoint(build *v1alpha1.Build) error {
-	status := build.Status
+func (nb *operation) Checkpoint(_ *v1alpha1.Build, status *v1alpha1.BuildStatus) error {
 	// Masquerade as the Google builder.
 	status.Builder = v1alpha1.GoogleBuildProvider
 	if status.Google == nil {

--- a/pkg/builder/nop/builder.go
+++ b/pkg/builder/nop/builder.go
@@ -40,7 +40,8 @@ type operation struct {
 
 func (nb *operation) Name() string { return operationName }
 
-func (nb *operation) Checkpoint(status *v1alpha1.BuildStatus) error {
+func (nb *operation) Checkpoint(build *v1alpha1.Build) error {
+	status := build.Status
 	// Masquerade as the Google builder.
 	status.Builder = v1alpha1.GoogleBuildProvider
 	if status.Google == nil {

--- a/pkg/builder/nop/builder_test.go
+++ b/pkg/builder/nop/builder_test.go
@@ -34,8 +34,11 @@ func TestBasicFlow(t *testing.T) {
 		t.Fatalf("Unexpected error executing builder.Build: %v", err)
 	}
 
-	var bs v1alpha1.BuildStatus
-	if err := op.Checkpoint(&bs); err != nil {
+	build := &v1alpha1.Build{
+		Status: v1alpha1.BuildStatus{},
+	}
+	bs := build.Status
+	if err := op.Checkpoint(build); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
 	if buildercommon.IsDone(&bs) {

--- a/pkg/builder/nop/builder_test.go
+++ b/pkg/builder/nop/builder_test.go
@@ -37,25 +37,24 @@ func TestBasicFlow(t *testing.T) {
 	build := &v1alpha1.Build{
 		Status: v1alpha1.BuildStatus{},
 	}
-	bs := build.Status
-	if err := op.Checkpoint(build); err != nil {
+	if err := op.Checkpoint(build, &build.Status); err != nil {
 		t.Fatalf("Unexpected error executing op.Checkpoint: %v", err)
 	}
-	if buildercommon.IsDone(&bs) {
-		t.Errorf("IsDone(%v); wanted not done, got done.", bs)
+	if buildercommon.IsDone(&build.Status) {
+		t.Errorf("IsDone(%v); wanted not done, got done.", build.Status)
 	}
-	op, err = builder.OperationFromStatus(&bs)
+	op, err = builder.OperationFromStatus(&build.Status)
 	if err != nil {
 		t.Fatalf("Unexpected error executing OperationFromStatus: %v", err)
 	}
-	if bs.CreationTime.IsZero() {
-		t.Errorf("bs.CreationTime; want non-zero, got %v", bs.CreationTime)
+	if build.Status.CreationTime.IsZero() {
+		t.Errorf("build.Status.CreationTime; want non-zero, got %v", build.Status.CreationTime)
 	}
-	if bs.StartTime.IsZero() {
-		t.Errorf("bs.StartTime; want non-zero, got %v", bs.StartTime)
+	if build.Status.StartTime.IsZero() {
+		t.Errorf("build.Status.StartTime; want non-zero, got %v", build.Status.StartTime)
 	}
-	if !bs.CompletionTime.IsZero() {
-		t.Errorf("bs.CompletionTime; want zero, got %v", bs.CompletionTime)
+	if !build.Status.CompletionTime.IsZero() {
+		t.Errorf("build.Status.CompletionTime; want zero, got %v", build.Status.CompletionTime)
 	}
 
 	status, err := op.Wait()

--- a/pkg/buildtest/diff.go
+++ b/pkg/buildtest/diff.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package buildtest
 
 import (

--- a/pkg/buildtest/diff.go
+++ b/pkg/buildtest/diff.go
@@ -1,0 +1,27 @@
+package buildtest
+
+import (
+	"encoding/json"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+func JSONDiff(l, r interface{}) string {
+	lb, err := json.MarshalIndent(l, "", " ")
+	if err != nil {
+		panic(err.Error())
+	}
+	rb, err := json.MarshalIndent(r, "", " ")
+	if err != nil {
+		panic(err.Error())
+	}
+
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(string(lb), string(rb), true)
+	for _, d := range diffs {
+		if d.Type != diffmatchpatch.DiffEqual {
+			return dmp.DiffPrettyText(diffs)
+		}
+	}
+	return ""
+}

--- a/pkg/controller/build/controller.go
+++ b/pkg/controller/build/controller.go
@@ -362,7 +362,7 @@ func (c *Controller) syncHandler(key string) error {
 				}
 				return err
 			}
-			if err := op.Checkpoint(build); err != nil {
+			if err := op.Checkpoint(build, &build.Status); err != nil {
 				return err
 			}
 			build, err = c.updateStatus(build)

--- a/pkg/controller/build/controller.go
+++ b/pkg/controller/build/controller.go
@@ -362,7 +362,7 @@ func (c *Controller) syncHandler(key string) error {
 				}
 				return err
 			}
-			if err := op.Checkpoint(&build.Status); err != nil {
+			if err := op.Checkpoint(build); err != nil {
 				return err
 			}
 			build, err = c.updateStatus(build)


### PR DESCRIPTION
Fixes #338 

## Proposed Changes

  * If a build specifies no source, skip only the first `StepState`
  * If the build specifies source, skip the first _two_ `StepState`s
  * Add tests, and move `diffmatchpatch` helper to `pkg/buildtest`

**Release Note**
```release-note
.Status.StepStates omits states for implicit steps, so the number of StepStates == number of user-specified build steps
```

/assign @shashwathi 