### PR TITLE
Add Pod affinity to builds

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -76,6 +76,9 @@ type BuildSpec struct {
 	// Specified build timeout should be less than 24h.
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	Timeout string `json:"timeout,omitempty"`
+	// If specified, the pod's scheduling constraints
+	// +optional
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 }
 
 // TemplateKind defines the type of BuildTemplate used by the build.

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -76,6 +76,7 @@ type BuildSpec struct {
 	// Specified build timeout should be less than 24h.
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	Timeout string `json:"timeout,omitempty"`
+
 	// If specified, the pod's scheduling constraints
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`

--- a/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
@@ -160,6 +160,15 @@ func (in *BuildSpec) DeepCopyInto(out *BuildSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Affinity)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/builder/cluster/convert/convert.go
+++ b/pkg/builder/cluster/convert/convert.go
@@ -372,6 +372,7 @@ func FromCRD(build *v1alpha1.Build, kubeclient kubernetes.Interface) (*corev1.Po
 			ServiceAccountName: build.Spec.ServiceAccountName,
 			Volumes:            volumes,
 			NodeSelector:       build.Spec.NodeSelector,
+			Affinity:           build.Spec.Affinity,
 		},
 	}, nil
 }
@@ -501,6 +502,7 @@ func ToCRD(pod *corev1.Pod) (*v1alpha1.Build, error) {
 			ServiceAccountName: podSpec.ServiceAccountName,
 			Volumes:            volumes,
 			NodeSelector:       podSpec.NodeSelector,
+			Affinity:           podSpec.Affinity,
 		},
 	}, nil
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -88,7 +88,6 @@ type buildClient struct {
 func (c *buildClient) watchBuild(name string) (*v1alpha1.Build, error) {
 	ls := metav1.SingleObject(metav1.ObjectMeta{Name: name})
 	// TODO: Update watchBuild function to take this as parameter depending on test requirements
-
 	// Set build timeout to 120 seconds. This will trigger watch timeout error
 	var timeout int64 = 120
 	ls.TimeoutSeconds = &timeout


### PR DESCRIPTION
Fixes #237 

## Proposed Changes

  * Operator can specify pod affinity for builds.
  * e2e test timesout because of missing pod constraints.