### PR TITLE
Make an Errorf be Fatalf instead.

### DIFF
--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -149,7 +149,7 @@ func TestBuildLowTimeout(t *testing.T) {
 
 	b, err := clients.buildClient.watchBuild(buildName)
 	if err == nil {
-		t.Error("watchBuild did not return expected BuildTimeout error")
+		t.Fatalf("watchBuild did not return expected BuildTimeout error")
 	}
 
 	if &b.Status == nil {


### PR DESCRIPTION
Otherwise we actually dereference a nil pointer in some cases.