### PR TITLE
Use custom nop image instead of busybox

### DIFF
--- a/cmd/nop/main.go
+++ b/cmd/nop/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Build successful")
+}

--- a/config/999-cache.yaml
+++ b/config/999-cache.yaml
@@ -39,3 +39,13 @@ metadata:
   namespace: knative-build
 spec:
   image: gcr.io/cloud-builders/gcs-fetcher
+---
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  name: nop
+  namespace: knative-build
+spec:
+  # This is the Go import path for the binary that is containerized
+  # and substituted here.
+  image: github.com/knative/build/cmd/nop

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -32,6 +32,7 @@ spec:
           "-stderrthreshold", "INFO",
           "-creds-image", "github.com/knative/build/cmd/creds-init",
           "-git-image", "github.com/knative/build/cmd/git-init",
+          "-nop-image", "github.com/knative/build/cmd/nop",
         ]
         volumeMounts:
         - name: config-logging

--- a/pkg/builder/cluster/convert/convert_test.go
+++ b/pkg/builder/cluster/convert/convert_test.go
@@ -32,6 +32,11 @@ import (
 
 var ignorePrivateResourceFields = cmpopts.IgnoreUnexported(resource.Quantity{})
 
+var nopContainer = corev1.Container{
+	Name:  "nop",
+	Image: *nopImage,
+}
+
 func read2CRD(f string) (*v1alpha1.Build, error) {
 	var bs v1alpha1.Build
 	if err := buildtest.DataAs(f, &bs.Spec); err != nil {


### PR DESCRIPTION
## Proposed Changes

  * Build a custom image with Go binary that prints `Build successful` and exits
  * Specify this image to the controller by flag
  * Use this image instead of `busybox` running `echo Build successful`
  * Cache this image

**Release Note**
```release-note
```
