### PR TITLE
[WIP] We now mount in emptyDir volumes for "$HOME/.ssh" and "$HOME/.docker"

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"bytes"
 	"flag"
-	"os"
 	"os/exec"
 
 	"github.com/knative/pkg/logging"
@@ -55,16 +54,6 @@ func main() {
 	flag.Parse()
 	logger, _ := logging.NewLogger("", "git-init")
 	defer logger.Sync()
-
-	// HACK HACK HACK
-	// Git seems to ignore $HOME/.ssh and look in /root/.ssh for unknown reasons.
-	// As a workaround, symlink /root/.ssh to where we expect the $HOME to land.
-	// This means SSH auth only works for our built-in git support, and not
-	// custom steps.
-	err := os.Symlink("/builder/home/.ssh", "/root/.ssh")
-	if err != nil {
-		logger.Fatalf("Unexpected error creating symlink: %v", err)
-	}
 
 	run(logger, "git", "init")
 	run(logger, "git", "remote", "add", "origin", *url)

--- a/pkg/builder/cluster/convert/convert.go
+++ b/pkg/builder/cluster/convert/convert.go
@@ -44,22 +44,25 @@ var (
 		EmptyDir: &corev1.EmptyDirVolumeSource{},
 	}
 	// These are injected into all of the source/step containers.
-	implicitEnvVars = []corev1.EnvVar{{
-		Name:  "HOME",
-		Value: "/builder/home",
-	}}
+	implicitEnvVars      = []corev1.EnvVar{}
 	implicitVolumeMounts = []corev1.VolumeMount{{
 		Name:      "workspace",
 		MountPath: workspaceDir,
 	}, {
-		Name:      "home",
-		MountPath: "/builder/home",
+		Name:      "home-docker",
+		MountPath: "/root/.docker",
+	}, {
+		Name:      "home-ssh",
+		MountPath: "/root/.ssh",
 	}}
 	implicitVolumes = []corev1.Volume{{
 		Name:         "workspace",
 		VolumeSource: emptyVolumeSource,
 	}, {
-		Name:         "home",
+		Name:         "home-docker",
+		VolumeSource: emptyVolumeSource,
+	}, {
+		Name:         "home-ssh",
 		VolumeSource: emptyVolumeSource,
 	}}
 )


### PR DESCRIPTION
This should resolve #117 as we don't need to change the "$HOME" env
var anymore