### PR TITLE
Fix columns.txt TYPE column

### DIFF
--- a/test/columns.txt
+++ b/test/columns.txt
@@ -1,2 +1,2 @@
 NAME	TYPE	STATUS	CREATED  START	END
-.metadata.name	.status.conditions[*].state	.status.conditions[*].status .status.creationTime .status.startTime	.status.completionTime
+.metadata.name	.status.conditions[*].type	.status.conditions[*].status .status.creationTime .status.startTime	.status.completionTime


### PR DESCRIPTION
Prior to this, `kubectl get builds -o=custom-columns-file=test/columns.txt` would show output like:

```
NAME                              TYPE     STATUS    ...
test-build                        <none>   True      ... 
```

After this change, it's:

```
NAME                              TYPE        STATUS    ...
test-build                        Succeeded   True      ...
```

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
