### PR TITLE
Move the use of `VerifyType` in tests

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
 )
@@ -45,9 +44,6 @@ type Build struct {
 
 // Check that our resource implements several interfaces.
 var _ kmeta.OwnerRefable = (*Build)(nil)
-
-// Check that Build implements the Conditions duck type.
-var _ = duck.VerifyType(&Build{}, &duckv1alpha1.Conditions{})
 
 // BuildSpec is the spec for a Build resource.
 type BuildSpec struct {

--- a/pkg/apis/build/v1alpha1/build_types_test.go
+++ b/pkg/apis/build/v1alpha1/build_types_test.go
@@ -23,10 +23,15 @@ import (
 	"github.com/knative/pkg/apis"
 
 	"github.com/knative/build/pkg/buildtest"
+	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 )
 
 const bazelYAML = "testdata/cloudbuilders/bazel/cloudbuild.yaml"
+
+func TestBuildImplementsConditions(t *testing.T) {
+	duck.VerifyType(&Build{}, &duckv1alpha1.Conditions{})
+}
 
 func TestParsing(t *testing.T) {
 	var bs BuildSpec


### PR DESCRIPTION
Related to  knative/pkg#97

## Proposed Changes

Those calls to `duck.VerifyType` are done at runtime and thus could be
costly at program startup. Putting them under tests ensure we still
assert those types but during unit testing.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
