### PR TITLE
Move build-base to the build dir in GCR

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,3 +1,3 @@
 baseImageOverrides:
-  github.com/knative/build/cmd/creds-init: gcr.io/knative-releases/build-base:latest
-  github.com/knative/build/cmd/git-init: gcr.io/knative-releases/build-base:latest
+  github.com/knative/build/cmd/creds-init: gcr.io/knative-releases/github.com/knative/build/build-base:latest
+  github.com/knative/build/cmd/git-init: gcr.io/knative-releases/github.com/knative/build/build-base:latest

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -39,9 +39,8 @@ run_validation_tests ./test/presubmit-tests.sh
 
 banner "Building the release"
 
-# Build and push the base image for creds-init and git images.
+# Build the base image for creds-init and git images.
 docker build -t ${BUILD_BASE_GCR} -f images/Dockerfile images/
-docker push ${BUILD_BASE}
 
 # Set the repository
 export KO_DOCKER_REPO=${BUILD_RELEASE_GCR}
@@ -64,6 +63,10 @@ echo "New release built successfully"
 if (( ! PUBLISH_RELEASE )); then
  exit 0
 fi
+
+# Push the base image for creds-init and git images.
+echo "Pushing base images to ${BUILD_BASE_GCR}"
+docker push ${BUILD_BASE_GCR}
 
 echo "Publishing ${OUTPUT_YAML}"
 publish_yaml ${OUTPUT_YAML} ${BUILD_RELEASE_GCS} ${TAG}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,6 +22,9 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 readonly BUILD_RELEASE_GCS
 readonly BUILD_RELEASE_GCR
 
+# Location of the base image for creds-init and git images
+readonly BUILD_BASE_GCR="${BUILD_RELEASE_GCR}/github.com/knative/build/build-base"
+
 # Local generated yaml file
 readonly OUTPUT_YAML=release.yaml
 
@@ -37,8 +40,8 @@ run_validation_tests ./test/presubmit-tests.sh
 banner "Building the release"
 
 # Build and push the base image for creds-init and git images.
-docker build -t $BUILD_RELEASE_GCR/build-base -f images/Dockerfile images/
-docker push $BUILD_RELEASE_GCR/build-base
+docker build -t ${BUILD_BASE_GCR} -f images/Dockerfile images/
+docker push ${BUILD_BASE}
 
 # Set the repository
 export KO_DOCKER_REPO=${BUILD_RELEASE_GCR}


### PR DESCRIPTION
Let's put all knative/build images together, it's cleaner.

Part of https://github.com/knative/test-infra/issues/161

Bonus: separate building and pushing the base images, so you can safely use `--nopublish`.