### PR TITLE
webhook: block execution

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -105,5 +105,5 @@ func main() {
 	go pkgcontroller.Run(stopCh)
 
 	buildWebhookController := webhook.NewAdmissionController(kubeClient, buildClient, bldr, pkgoptions, logger)
-	go buildWebhookController.Run(stopCh)
+	buildWebhookController.Run(stopCh)
 }


### PR DESCRIPTION
Otherwise, the command will return immediately. Should fix the crashloop on the `build-webhook` pod on master

/cc @shashankmjain @bbrowning 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
