### PR TITLE
Update test documentation

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,9 @@ _By default `go test` will not run [the e2e tests](#running-end-to-end-tests), w
 
 ## Running end to end tests
 
-To run [the e2e tests](./e2e), you need to have a running environment that meets
+### Go e2e tests
+
+To run [the Go e2e tests](./e2e), you need to have a running environment that meets
 [the e2e test environment requirements](#environment-requirements), and you need to specify the build tag `e2e`.
 
 ```bash
@@ -25,6 +27,15 @@ go test -v -tags=e2e -count=1 ./test/e2e/...
 ```
 
 `-count=1` is the idiomatic way to bypass test caching, so that tests will always run.
+
+### YAML e2e tests
+
+To run the YAML e2e tests, you need to have a running environment that meets
+[the e2e test environment requirements](#environment-requirements).
+
+```bash
+./test/e2e-yaml-tests.sh
+```
 
 ### One test case
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,39 @@
+# Test
+
+This directory contains tests and testing docs for `Knative Build`:
+
+* [Unit tests](#running-unit-tests) currently reside in the codebase alongside the code they test
+* [End-to-end tests](#running-end-to-end-tests), of which there are two types:
+## Running unit tests
+
+To run all unit tests:
+
+```bash
+go test ./...
+```
+
+_By default `go test` will not run [the e2e tests](#running-end-to-end-tests), which need [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
+
+
+## Running end to end tests
+
+To run [the e2e tests](./e2e), you need to have a running environment that meets
+[the e2e test environment requirements](#environment-requirements), and you need to specify the build tag `e2e`.
+
+```bash
+go test -v -tags=e2e -count=1 ./test/e2e/...
+```
+
+`-count=1` is the idiomatic way to bypass test caching, so that tests will always run.
+
+### One test case
+
+To run one e2e test case, e.g. TestSimpleBuild, use [the `-run` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags):
+
+```bash
+go test -v -tags=e2e -count=1 ./test/e2e/... -run=<regex>
+```
+
+### Environment requirements
+
+These tests require [a running `Knative Build` cluster.](/DEVELOPMENT.md#getting-started)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function teardown() {
+  ko delete --ignore-not-found=true -R -f test/
+  ko delete --ignore-not-found=true -f config/
+}
+
+function run_yaml_tests() {
+  echo ">> Starting tests"
+  ko apply -R -f test/ || return 1
+
+  # Wait for tests to finish.
+  echo ">> Waiting for tests to finish"
+  local tests_finished=0
+  for i in {1..60}; do
+    local finished="$(kubectl get builds --output=jsonpath='{.items[*].status.conditions[*].status}')"
+    if [[ ! "$finished" == *"Unknown"* ]]; then
+      tests_finished=1
+      break
+    fi
+    sleep 5
+  done
+  if (( ! tests_finished )); then
+    echo "ERROR: tests timed out"
+    return 1
+  fi
+
+  # Check that tests passed.
+  local failed=0
+  echo ">> Checking test results"
+  for expected_status in succeeded failed; do
+    results="$(kubectl get builds -l expect=${expected_status} \
+	--output=jsonpath='{range .items[*]}{.metadata.name}={.status.conditions[*].type}{.status.conditions[*].status}{" "}{end}')"
+    case $expected_status in
+      succeeded)
+	want=succeededtrue
+	;;
+      failed)
+	want=succeededfalse
+	;;
+      *)
+	echo "ERROR: Invalid expected status '${expected_status}'"
+	failed=1
+	;;
+    esac
+    for result in ${results}; do
+      if [[ ! "${result,,}" == *"=${want}" ]]; then
+	echo "ERROR: test ${result} but should be ${want}"
+	failed=1
+      fi
+    done
+  done
+  (( failed )) && return 1
+  echo ">> All YAML tests passed"
+  return 0
+}

--- a/test/e2e-yaml-tests.sh
+++ b/test/e2e-yaml-tests.sh
@@ -14,32 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script runs the end-to-end tests against the build controller
-# built from source. It is started by prow for each PR.
-# For convenience, it can also be executed manually.
-
-# If you already have the *_OVERRIDE environment variables set, call
-# this script with the --run-tests arguments and it will use the cluster
-# and run the tests.
-
-# Calling this script without arguments will create a new cluster in
-# project $PROJECT_ID, start the controller, run the tests and delete
-# the cluster.
+# This script runs the YAML end-to-end tests against the build controller
+# built from source. It is not run by prow for each PR, see e2e-tests.sh for that.
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 source $(dirname $0)/e2e-common.sh
-
-
-# Script entry point.
-
-initialize $@
 
 # Fail fast during setup.
 set -o errexit
 set -o pipefail
 
 header "Building and starting the controller"
-export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 ko apply -f config/ || fail_test
 
 # Handle test failures ourselves, so we can dump useful info.
@@ -53,9 +38,6 @@ kubectl delete --ignore-not-found=true buildtemplates --all
 # Run the tests
 
 failed=0
-
-header "Running Go e2e tests"
-report_go_test -tags e2e ./test/e2e/... -count=1 || failed=1
 
 header "Running YAML e2e tests"
 if ! run_yaml_tests; then

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -4,7 +4,7 @@
 
 ## Adding end to end tests
 
-Knative Serving e2e tests [test the end to end functionality of the Knative Build API](#requirements) to verify the behavior of this specific implementation.
+Knative Build e2e tests [test the end to end functionality of the Knative Build API](#requirements) to verify the behavior of this specific implementation.
 
 ### Requirements
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,25 +1,16 @@
-# End-to-End testing
+# End to end tests
 
-## Running the tests
+* [Running e2e tests](../README.md#running-e2e-tests)
 
-To run all e2e tests:
-```
-go test -tags e2e ./test/e2e/... -count=1
-```
+## Adding end to end tests
 
-`-count=1` is the idiomatic way to bypass test caching, so that tests will
-always run.
+Knative Serving e2e tests [test the end to end functionality of the Knative Build API](#requirements) to verify the behavior of this specific implementation.
 
-To run a single e2e test:
+### Requirements
 
-```
-go test -tags e2e ./test/e2e/... -count=1 -test.run=<regex>
-```
+The e2e tests are used to test whether the flow of Knative Build is performing as designed from start to finish.
 
-## What the tests do
+The e2e tests **MUST**:
 
-By default, tests use your current Kubernetes config to talk to your currently
-configured cluster.
-
-When they run tests ensure that a namespace named `build-tests` exists, then
-starts running builds in it.
+1. Provide frequent output describing what actions they are undertaking, especially before performing long running operations.
+2. Follow Golang best practices.


### PR DESCRIPTION
Taking from `serving` `test/README`(s), this updates the documentation
to run the unit tests and e2e tests locally.

/cc @shashwathi @ImJasonH 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
