### PR TITLE
Migrate last pieces of build.dev to build.knative.dev

### DIFF
--- a/pkg/builder/cluster/convert/convert_test.go
+++ b/pkg/builder/cluster/convert/convert_test.go
@@ -78,10 +78,10 @@ func TestRoundtrip(t *testing.T) {
 				}},
 			}, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "multi-creds",
-					Annotations: map[string]string{"build.dev/docker-0": "https://us.gcr.io",
-						"build.dev/docker-1": "https://docker.io",
-						"build.dev/git-0":    "github.com",
-						"build.dev/git-1":    "gitlab.com",
+					Annotations: map[string]string{"build.knative.dev/docker-0": "https://us.gcr.io",
+						"build.knative.dev/docker-1": "https://docker.io",
+						"build.knative.dev/git-0":    "github.com",
+						"build.knative.dev/git-1":    "gitlab.com",
 					}},
 				Type: "kubernetes.io/basic-auth",
 				Data: map[string][]byte{

--- a/pkg/webhook/build.go
+++ b/pkg/webhook/build.go
@@ -130,7 +130,7 @@ func (ac *AdmissionController) validateSecrets(b *v1alpha1.Build) error {
 		// them outright before a Build ever uses them. This would
 		// remove latency at Build-time.
 		for k, v := range sec.Annotations {
-			if strings.HasPrefix(k, "build.dev/docker-") && v == "index.docker.io" {
+			if strings.HasPrefix(k, "build.knative.dev/docker-") && v == "index.docker.io" {
 				return validationError("BadSecretAnnotation", `Secret %q has incorrect annotation %q / %q, value should be "https://index.docker.io/v1/"`, se.Name, k, v)
 			}
 		}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -401,7 +401,7 @@ func TestValidateBuild(t *testing.T) {
 		secrets: []*corev1.Secret{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "good-sekrit",
-				Annotations: map[string]string{"build.dev/docker-0": "https://index.docker.io/v1/"},
+				Annotations: map[string]string{"build.knative.dev/docker-0": "https://index.docker.io/v1/"},
 			},
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
@@ -411,7 +411,7 @@ func TestValidateBuild(t *testing.T) {
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "one-more-good-sekrit",
-				Annotations: map[string]string{"build.dev/docker-1": "gcr.io"},
+				Annotations: map[string]string{"build.knative.dev/docker-1": "gcr.io"},
 			},
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
@@ -433,7 +433,7 @@ func TestValidateBuild(t *testing.T) {
 		secrets: []*corev1.Secret{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "bad-sekrit",
-				Annotations: map[string]string{"build.dev/docker-0": "index.docker.io"},
+				Annotations: map[string]string{"build.knative.dev/docker-0": "index.docker.io"},
 			},
 		}},
 		reason: "BadSecretAnnotation",


### PR DESCRIPTION
Fixes #397 

> PR https://github.com/knative/build/pull/204 renamed `*.build.dev` in `build.knative.dev`. Somehow there is still some code that refers to the old `build.dev` name, mainly for webook secret validate

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
