### PR TITLE
Update issue and PR templates

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,26 +1,23 @@
 <!--
-Uncomment and remove leading >, leaving one or more of the following to ensure
-that the appropriate working groups are aware of the issue:
+Pro-tip: You can leave this block commented, and it still works!
 
-> /area API
-> /area monitoring
-> /area test-and-release
+Select the appropriate areas for your issue and remove the leading >
 
--->
+/area API
+/area monitoring
+/area test-and-release
 
-<!--
-Uncomment and remove leading >, leaving one or more of the following to
-classify the kind of issue:
+Classify what kind of issue this is:
 
-> /kind bug
-> /kind dev
-> /kind doc
--->
+/kind question
+/kind bug
+/kind cleanup
+/kind doc
+/kind feature
+/kind good-first-issue
+/kind process
+/kind spec
 
-<!--
-You may also assign an issue via (remove leading >)
-
-> /assign @user
 -->
 
 ## Expected Behavior

--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -3,20 +3,20 @@ Pro-tip: You can leave this block commented, and it still works!
 
 Select the appropriate areas for your issue and remove the leading >
 
-/area API
-/area monitoring
-/area test-and-release
+> /area API
+> /area monitoring
+> /area test-and-release
 
 Classify what kind of issue this is:
 
-/kind question
-/kind bug
-/kind cleanup
-/kind doc
-/kind feature
-/kind good-first-issue
-/kind process
-/kind spec
+> /kind question
+> /kind bug
+> /kind cleanup
+> /kind doc
+> /kind feature
+> /kind good-first-issue
+> /kind process
+> /kind spec
 
 -->
 

--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,25 +1,26 @@
 <!--
-Uncomment leaving one or more of the following to ensure that the appropriate
-working groups are aware of the issue:
+Uncomment and remove leading >, leaving one or more of the following to ensure
+that the appropriate working groups are aware of the issue:
 
-/area API
-/area monitoring
-/area test-and-release
+> /area API
+> /area monitoring
+> /area test-and-release
 
 -->
 
 <!--
-Uncomment leaving one or more of the following to classify the kind of issue:
+Uncomment and remove leading >, leaving one or more of the following to
+classify the kind of issue:
 
-/kind bug
-/kind dev
-/kind doc
+> /kind bug
+> /kind dev
+> /kind doc
 -->
 
 <!--
-You may also assign an issue via:
+You may also assign an issue via (remove leading >)
 
-/assign @user
+> /assign @user
 -->
 
 ## Expected Behavior

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -12,3 +12,9 @@ additional action from users switching to the new release, include the string
 "action required". If no release note is required, write "NONE". -->
 ```release-note
 ```
+
+<!--
+Request Prow to automatically lint any go code in this PR:
+
+/lint
+-->


### PR DESCRIPTION
## Proposed Changes

  * Make it harder for users to accidentally add a rainbow of labels and assign a non-member user ([this poor sap](https://github.com/user)). Now users must explicitly remove the leading `>` to add a `kind` or `area` label or `assign` a user.
  * Tell Prow to `/lint` PRs by default

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```
