### PR TITLE
Extract the ApplyReplacements logic from ApplyTemplate.

### DIFF
--- a/pkg/builder/common.go
+++ b/pkg/builder/common.go
@@ -52,6 +52,14 @@ func ApplyTemplate(u *v1alpha1.Build, tmpl v1alpha1.BuildTemplateInterface) (*v1
 		}
 	}
 
+	build = ApplyReplacements(build, replacements)
+	return build, nil
+}
+
+// ApplyReplacements replaces placeholders for declared parameters with the specified replacements.
+func ApplyReplacements(build *v1alpha1.Build, replacements map[string]string) *v1alpha1.Build {
+	build = build.DeepCopy()
+
 	applyReplacements := func(in string) string {
 		for k, v := range replacements {
 			in = strings.Replace(in, fmt.Sprintf("${%s}", k), v, -1)
@@ -92,8 +100,7 @@ func ApplyTemplate(u *v1alpha1.Build, tmpl v1alpha1.BuildTemplateInterface) (*v1
 			steps[i].Env = applyEnvOverride(steps[i].Env, buildTmpl.Env)
 		}
 	}
-
-	return build, nil
+	return build
 }
 
 func applyEnvOverride(src, override []corev1.EnvVar) []corev1.EnvVar {


### PR DESCRIPTION
This functionality will be used in build-pipeline as well, and reusing
this logic will help ensure consistency.

Should be used for https://github.com/knative/build-pipeline/issues/64

## Proposed Changes

  * Extract logic from ApplyTemplate into a new, public function `ApplyReplacements`

**Release Note**
```release-note
NONE
```

/lint
