### PR TITLE
Sort docker and git credentials

### DIFF
--- a/pkg/credentials/dockercreds/creds.go
+++ b/pkg/credentials/dockercreds/creds.go
@@ -131,10 +131,8 @@ func (*dockerConfigBuilder) MatchingAnnotations(secret *corev1.Secret) []string 
 		return flags
 	}
 
-	for k, v := range secret.Annotations {
-		if strings.HasPrefix(k, annotationPrefix) {
-			flags = append(flags, fmt.Sprintf("-basic-docker=%s=%s", secret.Name, v))
-		}
+	for _, v := range credentials.SortAnnotations(secret.Annotations, annotationPrefix) {
+		flags = append(flags, fmt.Sprintf("-basic-docker=%s=%s", secret.Name, v))
 	}
 	return flags
 }

--- a/pkg/credentials/gitcreds/creds.go
+++ b/pkg/credentials/gitcreds/creds.go
@@ -19,7 +19,6 @@ package gitcreds
 import (
 	"flag"
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -71,10 +70,8 @@ func (*gitConfigBuilder) MatchingAnnotations(secret *corev1.Secret) []string {
 		return flags
 	}
 
-	for k, v := range secret.Annotations {
-		if strings.HasPrefix(k, annotationPrefix) {
-			flags = append(flags, fmt.Sprintf("-%s=%s=%s", flagName, secret.Name, v))
-		}
+	for _, v := range credentials.SortAnnotations(secret.Annotations, annotationPrefix) {
+		flags = append(flags, fmt.Sprintf("-%s=%s=%s", flagName, secret.Name, v))
 	}
 	return flags
 }

--- a/pkg/credentials/initialize.go
+++ b/pkg/credentials/initialize.go
@@ -18,6 +18,8 @@ package credentials
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -40,4 +42,18 @@ type Builder interface {
 // VolumeName returns the full path to the secret, inside the VolumePath.
 func VolumeName(secretName string) string {
 	return fmt.Sprintf("%s/%s", VolumePath, secretName)
+}
+
+// SortAnnotations alphabetically
+func SortAnnotations(secrets map[string]string, annotationPrefix string) []string {
+	var mk []string
+	i := 0
+	for k, v := range secrets {
+		if strings.HasPrefix(k, annotationPrefix) {
+			mk = append(mk, v)
+			i++
+		}
+	}
+	sort.Strings(mk)
+	return mk
 }


### PR DESCRIPTION
## Proposed Changes

  * If build uses secret that has multiple annotations then they are sorted alphabetically
  * Reduces random picking of key. 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
