### PR TITLE
Use downward API instead of hard-coding build namespace

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -37,6 +37,11 @@ spec:
           "-git-image", "github.com/knative/build/cmd/git-init",
           "-nop-image", "github.com/knative/build/cmd/nop",
         ]
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -38,6 +38,11 @@ spec:
           "-logtostderr",
           "-stderrthreshold", "INFO",
         ]
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging

--- a/pkg/system/names.go
+++ b/pkg/system/names.go
@@ -16,8 +16,17 @@ limitations under the License.
 
 package system
 
-const (
+import "os"
+
+var (
 	// Namespace holds the K8s namespace where our build system
 	// components run.
-	Namespace = "knative-build"
+	Namespace string
 )
+
+func init() {
+	Namespace = os.Getenv("SYSTEM_NAMESPACE")
+	if Namespace == "" {
+		Namespace = "knative-build"
+	}
+}


### PR DESCRIPTION
In anticipation of #391, this removes the hard-coded namespace from the go source by using the downward API per @mattmoor 's example.

Removing the namespace from the yaml manifests is more complicated, as it will likely impact the install instructions and the test/release infrastructure.
