### PR TITLE
Use gcr.io/distroless/base for the build-base image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,13 +19,16 @@ container_pull(
     name = "base",
     registry = "gcr.io",
     repository = "distroless/base",
+    # "gcr.io/distroless/base:latest" circa 2018-10-16 21:01 -0400
+    digest = "sha256:472206d4c501691d9e72cafca4362f2adbc610fecff3dfa42e5b345f9b7d05e5"
 )
 
 container_pull(
     name = "base-debug",
     registry = "gcr.io",
     repository = "distroless/base",
-    tag = "debug",
+    # "gcr.io/distroless/base:debug" circa 2018-10-16 21:01 -0400
+    digest = "sha256:bb7b331d3132e95c48556dbd3b28079f0eb3014f2726f5ddd7225b9c9df16a91",
 )
 
 # Load distroless rules

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,115 @@
+workspace(name = "buildcrd")
+
+# Load docker rules
+git_repository(
+    name = "io_bazel_rules_docker",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+    tag = "v0.5.1",
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+container_pull(
+    name = "base",
+    registry = "gcr.io",
+    repository = "distroless/base",
+)
+
+container_pull(
+    name = "base-debug",
+    registry = "gcr.io",
+    repository = "distroless/base",
+    tag = "debug",
+)
+
+# Load distroless rules
+git_repository(
+    name = "distroless",
+    remote = "https://github.com/GoogleContainerTools/distroless",
+    commit = "f93e9b5c88a0ac6b98bc4ff94d206702cfb4e7e3",
+)
+
+load(
+    "@distroless//package_manager:package_manager.bzl",
+    "dpkg_list",
+    "dpkg_src",
+    "package_manager_repositories",
+)
+
+package_manager_repositories()
+
+dpkg_src(
+    name = "debian_stretch",
+    arch = "amd64",
+    distro = "stretch",
+    sha256 = "9e7870c3c3b5b0a7f8322c323a3fa641193b1eee792ee7e2eedb6eeebf9969f3",
+    snapshot = "20180719T151130Z",
+    url = "https://snapshot.debian.org/archive",
+)
+
+dpkg_src(
+    name = "debian_stretch_backports",
+    arch = "amd64",
+    distro = "stretch-backports",
+    sha256 = "29524787f58bc4e139e30e66bc476ff1ea33c0aa939d11638626dbe07c64b30d",
+    snapshot = "20180919T095426Z",
+    url = "http://snapshot.debian.org/archive",
+)
+
+dpkg_src(
+    name = "debian_stretch_security",
+    package_prefix = "https://snapshot.debian.org/archive/debian-security/20180919T095426Z/",
+    packages_gz_url = "https://snapshot.debian.org/archive/debian-security/20180919T095426Z/dists/stretch/updates/main/binary-amd64/Packages.gz",
+    sha256 = "4b7df485333ed77ccc9bb4fea9bffe302dc4d0e2303f27b39dc6a4cfcfe5fca5",
+)
+
+dpkg_list(
+    name = "package_bundle",
+    packages = [
+      # https://packages.debian.org/stretch/openssh-client
+      "openssh-client",
+        # openssh-clients deps
+        "libedit2",
+          # libedit2 deps
+          "libncurses5",
+          "libbsd0",
+          "libtinfo5",
+        "libgssapi-krb5-2",
+          # libgssapi-krb5-2 deps
+          "libcomerr2",
+          "libcom-err2", # This is pulled due to backport selection
+          "libk5crypto3",
+          "libkeyutils1",
+          "libkrb5-3",
+          "libkrb5support0",
+        "libselinux1",
+          # libselinux1 deps
+          # "libpcre3",  #provided by git below
+        "libssl1.0.2",
+      # "zlib1g", # provided by git below
+
+      # https://packages.debian.org/stretch/git
+      "git",
+      # "libc6" # provided by distroless/base
+      "libcurl3-gnutls",
+      "liberror-perl",
+      "libexpat1",
+      "libpcre3",
+      "perl",
+      "zlib1g",
+    ],
+    # Takes the first package found: security updates should go first
+    # If there was a security fix to a package before the stable release, this will find
+    # the older security release. This happened for stretch libc6.
+    sources = [
+        "@debian_stretch_security//file:Packages.json",
+        "@debian_stretch_backports//file:Packages.json",
+        "@debian_stretch//file:Packages.json",
+    ],
+)

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,10 +23,24 @@ readonly BUILD_RELEASE_GCS
 readonly BUILD_RELEASE_GCR
 
 # Location of the base image for creds-init and git images
-readonly BUILD_BASE_GCR="${BUILD_RELEASE_GCR}/github.com/knative/build/build-base"
+(( PUBLISH_RELEASE )) && BUILD_BASE_REGISTRY="gcr.io" || BUILD_BASE_REGISTRY="ko.local"
+readonly BUILD_BASE_REGISTRY
+readonly BUILD_BASE_REPO="knative-releases/github.com/knative/build/build-base"
 
 # Local generated yaml file
 readonly OUTPUT_YAML=release.yaml
+
+function bazel_cleanup() {
+  bazel clean --expunge
+}
+
+function ko_build() {
+  echo "Building build-crd"
+  ko resolve ${KO_FLAGS} -f config/ > ${OUTPUT_YAML}
+  tag_images_in_yaml ${OUTPUT_YAML} ${BUILD_RELEASE_GCR} ${TAG}
+
+  echo "New release built successfully"
+}
 
 # Script entry point
 
@@ -35,12 +49,17 @@ parse_flags $@
 set -o errexit
 set -o pipefail
 
-run_validation_tests ./test/presubmit-tests.sh
+trap bazel_cleanup EXIT
+
+#run_validation_tests ./test/presubmit-tests.sh
 
 banner "Building the release"
 
 # Build the base image for creds-init and git images.
-docker build -t ${BUILD_BASE_GCR} -f images/Dockerfile images/
+bazel build \
+  --define registry=${BUILD_BASE_REGISTRY} \
+  --define repository=${BUILD_BASE_REPO} \
+  //images:all
 
 # Set the repository
 export KO_DOCKER_REPO=${BUILD_RELEASE_GCR}
@@ -49,24 +68,28 @@ export K8S_CLUSTER_OVERRIDE=CLUSTER_NOT_SET
 export K8S_USER_OVERRIDE=USER_NOT_SET
 export DOCKER_REPO_OVERRIDE=DOCKER_NOT_SET
 
-if (( PUBLISH_RELEASE )); then
-  echo "- Destination GCR: ${BUILD_RELEASE_GCR}"
-  echo "- Destination GCS: ${BUILD_RELEASE_GCS}"
-fi
-
-echo "Building build-crd"
-ko resolve ${KO_FLAGS} -f config/ > ${OUTPUT_YAML}
-tag_images_in_yaml ${OUTPUT_YAML} ${BUILD_RELEASE_GCR} ${TAG}
-
-echo "New release built successfully"
-
 if (( ! PUBLISH_RELEASE )); then
- exit 0
+  ko_build
+  exit 0
 fi
 
-# Push the base image for creds-init and git images.
-echo "Pushing base images to ${BUILD_BASE_GCR}"
-docker push ${BUILD_BASE_GCR}
+# Push the base image for creds-init and git images. We push the
+# images first so that ko_build will pick up the latest changes
+echo "Pushing base images to ${BUILD_BASE_REGISTRY}/${BUILD_BASE_REPO}"
+bazel run \
+  --define registry=${BUILD_BASE_REGISTRY} \
+  --define repository=${BUILD_BASE_REPO} \
+  //images:push-build-base
+
+bazel run \
+  --define registry=${BUILD_BASE_REGISTRY} \
+  --define repository=${BUILD_BASE_REPO} \
+  //images:push-build-base-debug
+
+echo "- Destination GCR: ${BUILD_RELEASE_GCR}"
+echo "- Destination GCS: ${BUILD_RELEASE_GCS}"
+
+ko_build
 
 echo "Publishing ${OUTPUT_YAML}"
 publish_yaml ${OUTPUT_YAML} ${BUILD_RELEASE_GCS} ${TAG}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -16,6 +16,12 @@
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 
+set -o errexit
+set -o pipefail
+
+# Script entry point
+parse_flags $@
+
 # Set default GCS/GCR
 : ${BUILD_RELEASE_GCS:="knative-releases/build"}
 : ${BUILD_RELEASE_GCR:="gcr.io/knative-releases"}
@@ -23,9 +29,16 @@ readonly BUILD_RELEASE_GCS
 readonly BUILD_RELEASE_GCR
 
 # Location of the base image for creds-init and git images
-(( PUBLISH_RELEASE )) && BUILD_BASE_REGISTRY="gcr.io" || BUILD_BASE_REGISTRY="ko.local"
+if (( PUBLISH_RELEASE )); then
+  BUILD_BASE_REGISTRY="$(echo $BUILD_RELEASE_GCR | cut -d/ -f1)"
+else
+  BUILD_BASE_REGISTRY="ko.local"
+fi
+
+BUILD_BASE_REPO="$(echo $BUILD_RELEASE_GCR | cut -d/ -f2-)/github.com/knative/build/build-base"
+
 readonly BUILD_BASE_REGISTRY
-readonly BUILD_BASE_REPO="knative-releases/github.com/knative/build/build-base"
+readonly BUILD_BASE_REPO
 
 # Local generated yaml file
 readonly OUTPUT_YAML=release.yaml
@@ -42,19 +55,13 @@ function ko_build() {
   echo "New release built successfully"
 }
 
-# Script entry point
-
-parse_flags $@
-
-set -o errexit
-set -o pipefail
-
 trap bazel_cleanup EXIT
 
-#run_validation_tests ./test/presubmit-tests.sh
+run_validation_tests ./test/presubmit-tests.sh
 
 banner "Building the release"
 
+echo "Building base images"
 # Build the base image for creds-init and git images.
 bazel build \
   --define registry=${BUILD_BASE_REGISTRY} \
@@ -73,6 +80,9 @@ if (( ! PUBLISH_RELEASE )); then
   exit 0
 fi
 
+echo "- Destination GCR: ${BUILD_RELEASE_GCR}"
+echo "- Destination GCS: ${BUILD_RELEASE_GCS}"
+
 # Push the base image for creds-init and git images. We push the
 # images first so that ko_build will pick up the latest changes
 echo "Pushing base images to ${BUILD_BASE_REGISTRY}/${BUILD_BASE_REPO}"
@@ -85,9 +95,6 @@ bazel run \
   --define registry=${BUILD_BASE_REGISTRY} \
   --define repository=${BUILD_BASE_REPO} \
   //images:push-build-base-debug
-
-echo "- Destination GCR: ${BUILD_RELEASE_GCR}"
-echo "- Destination GCS: ${BUILD_RELEASE_GCS}"
 
 ko_build
 

--- a/images/BUILD
+++ b/images/BUILD
@@ -1,0 +1,72 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@package_bundle//file:packages.bzl",
+    "packages",
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+    "container_push",
+)
+
+deb_packages = [
+    # See WORKSPACE for the dependency tree
+    # and links to the debian packages online
+    packages["openssh-client"],
+    packages["libedit2"],
+    packages["libgssapi-krb5-2"],
+    packages["libselinux1"],
+    packages["libssl1.0.2"],
+    # libedit2 deps
+    packages["libncurses5"],
+    packages["libbsd0"],
+    packages["libtinfo5"],
+    # libgssapi-krb5-2 deps
+    packages["libcomerr2"],
+    packages["libcom-err2"],
+    packages["libk5crypto3"],
+    packages["libkeyutils1"],
+    packages["libkrb5-3"],
+    packages["libkrb5support0"],
+
+    packages["git"],
+    packages["libcurl3-gnutls"],
+    packages["liberror-perl"],
+    packages["libexpat1"],
+    packages["libpcre3"],
+    packages["perl"],
+    packages["zlib1g"],
+]
+
+container_image(
+    name = "build-base",
+    base = "@base//image",
+    debs = deb_packages,
+)
+
+container_image(
+    name = "build-base-debug",
+    base = "@base-debug//image",
+    debs = deb_packages,
+)
+
+container_push(
+   name = "push-build-base",
+   image = ":build-base",
+   format = "Docker",
+   registry = "$(registry)",
+   repository = "$(repository)",
+   tag = "latest",
+)
+
+container_push(
+   name = "push-build-base-debug",
+   image = ":build-base-debug",
+   format = "Docker",
+   registry = "$(registry)",
+   repository = "$(repository)",
+   tag = "debug",
+)
+

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,0 @@
-FROM alpine:latest
-  
-RUN apk add --update git openssh-client
-


### PR DESCRIPTION
This makes Knative container images uniform for the sake of
license scanning

Bazel is introduced again so we can use rules provided by
github.com/GoogleContainerTools/distroless to build our base
container images