### PR TITLE
Fix e2e:TestInvalidBuild flakiness 

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -29,6 +29,16 @@
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 source $(dirname $0)/e2e-common.sh
 
+function wait_for_running_build_pods() {
+  echo "Waiting for knative build pods to be ready..."
+  local pods=$(kubectl get pods -o name -n knative-build)
+
+  for pod in $pods
+  do
+    kubectl wait --for=condition=Ready -n knative-build "$pod"
+  done
+  echo "Knative build pods are ready"
+}
 
 # Script entry point.
 
@@ -49,6 +59,8 @@ set +o pipefail
 # Make sure that are no builds or build templates in the current namespace.
 kubectl delete --ignore-not-found=true builds --all
 kubectl delete --ignore-not-found=true buildtemplates --all
+
+wait_for_running_build_pods
 
 # Run the tests
 


### PR DESCRIPTION
My current theory is the webhook is not registered/running when the tests start.

This waits until all pods in the knative-build namespace have their 'Ready' condition set to true.