### PR TITLE
end to end tests will now test changes to the base image

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,9 +22,6 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 readonly BUILD_RELEASE_GCS
 readonly BUILD_RELEASE_GCR
 
-# Location of the base image for creds-init and git images
-readonly BUILD_BASE_GCR="${BUILD_RELEASE_GCR}/github.com/knative/build/build-base"
-
 # Local generated yaml file
 readonly OUTPUT_YAML=release.yaml
 
@@ -40,7 +37,7 @@ run_validation_tests ./test/presubmit-tests.sh
 banner "Building the release"
 
 # Build the base image for creds-init and git images.
-docker build -t ${BUILD_BASE_GCR} -f images/Dockerfile images/
+SKIP_BUILD_BASE_PUSH=1 hack/upload-build-images.sh
 
 # Set the repository
 export KO_DOCKER_REPO=${BUILD_RELEASE_GCR}
@@ -65,8 +62,7 @@ if (( ! PUBLISH_RELEASE )); then
 fi
 
 # Push the base image for creds-init and git images.
-echo "Pushing base images to ${BUILD_BASE_GCR}"
-docker push ${BUILD_BASE_GCR}
+hack/upload-build-images.sh
 
 echo "Publishing ${OUTPUT_YAML}"
 publish_yaml ${OUTPUT_YAML} ${BUILD_RELEASE_GCS} ${TAG}

--- a/hack/upload-build-images.sh
+++ b/hack/upload-build-images.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the base image for creds-init and git images.
+
+: ${BUILD_BASE_REGISTRY:="gcr.io"}
+: ${BUILD_BASE_REPO:="knative-releases/github.com/knative/build/build-base"}
+: ${BUILD_BASE_TAG:="latest"}
+: ${BUILD_BASE_IMAGE:="${BUILD_BASE_REGISTRY}/${BUILD_BASE_REPO}:${BUILD_BASE_TAG}"}
+
+readonly BUILD_BASE_REGISTRY
+readonly BUILD_BASE_REPO
+readonly BUILD_BASE_TAG
+readonly BUILD_BASE_IMAGE
+
+# Build the base image for creds-init and git images.
+echo "Building the build-base image"
+docker build -t "${BUILD_BASE_IMAGE}" -f images/Dockerfile images/
+
+if (( ! SKIP_BUILD_BASE_PUSH )); then
+  echo "Pushing the build-base image to ${BUILD_BASE_IMAGE}"
+  docker push "${BUILD_BASE_IMAGE}"
+fi

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:latest
-  
+
 RUN apk add --update git openssh-client
 


### PR DESCRIPTION
Fixes #428 

/hold

- [x] Depends on this `ko` change https://github.com/google/go-containerregistry/pull/294
- [ ] Test `hack/release.sh`
