### PR TITLE
Use fully-qualified name to avoid conflict w/Openshift Builds

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -27,7 +27,7 @@ function run_yaml_tests() {
   echo ">> Waiting for tests to finish"
   local tests_finished=0
   for i in {1..60}; do
-    local finished="$(kubectl get builds --output=jsonpath='{.items[*].status.conditions[*].status}')"
+    local finished="$(kubectl get build.build.knative.dev --output=jsonpath='{.items[*].status.conditions[*].status}')"
     if [[ ! "$finished" == *"Unknown"* ]]; then
       tests_finished=1
       break
@@ -43,7 +43,7 @@ function run_yaml_tests() {
   local failed=0
   echo ">> Checking test results"
   for expected_status in succeeded failed; do
-    results="$(kubectl get builds -l expect=${expected_status} \
+    results="$(kubectl get build.build.knative.dev -l expect=${expected_status} \
 	--output=jsonpath='{range .items[*]}{.metadata.name}={.status.conditions[*].type}{.status.conditions[*].status}{" "}{end}')"
     case $expected_status in
       succeeded)

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -46,7 +46,7 @@ set +o errexit
 set +o pipefail
 
 # Make sure that are no builds or build templates in the current namespace.
-kubectl delete --ignore-not-found=true builds --all
+kubectl delete --ignore-not-found=true builds.build.knative.dev --all
 kubectl delete --ignore-not-found=true buildtemplates --all
 
 wait_until_pods_running knative-build
@@ -63,8 +63,8 @@ if ! run_yaml_tests; then
   failed=1
   echo "ERROR: one or more YAML tests failed"
   # If formatting fails for any reason, use yaml as a fall back.
-  kubectl get builds -o=custom-columns-file=./test/columns.txt || \
-    kubectl get builds -oyaml
+  kubectl get builds.build.knative.dev -o=custom-columns-file=./test/columns.txt || \
+    kubectl get builds.build.knative.dev -oyaml
 fi
 
 (( failed )) && fail_test

--- a/test/e2e-yaml-tests.sh
+++ b/test/e2e-yaml-tests.sh
@@ -32,7 +32,7 @@ set +o errexit
 set +o pipefail
 
 # Make sure that are no builds or build templates in the current namespace.
-kubectl delete --ignore-not-found=true builds --all
+kubectl delete --ignore-not-found=true builds.build.knative.dev --all
 kubectl delete --ignore-not-found=true buildtemplates --all
 
 # Run the tests
@@ -44,8 +44,8 @@ if ! run_yaml_tests; then
   failed=1
   echo "ERROR: one or more YAML tests failed"
   # If formatting fails for any reason, use yaml as a fall back.
-  kubectl get builds -o=custom-columns-file=./test/columns.txt || \
-    kubectl get builds -oyaml
+  kubectl get builds.build.knative.dev -o=custom-columns-file=./test/columns.txt || \
+    kubectl get builds.build.knative.dev -oyaml
 fi
 
 (( failed )) && fail_test


### PR DESCRIPTION
Since Openshift provides its own Build CRD, that name takes precedence
and causes the e2e test logic to fail.

Using the FQN should enable tests to pass on either k8s or openshift platforms.