### PR TITLE
Add optional tags for build spec

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -222,11 +222,11 @@ type BuildStatus struct {
 
 	// StartTime is the time the build is actually started.
 	// +optional
-	StartTime metav1.Time `json:"startTime,omitEmpty"`
+	StartTime *metav1.Time `json:"startTime,omitEmpty"`
 
 	// CompletionTime is the time the build completed.
 	// +optional
-	CompletionTime metav1.Time `json:"completionTime,omitEmpty"`
+	CompletionTime *metav1.Time `json:"completionTime,omitEmpty"`
 
 	// StepStates describes the state of each build step container.
 	// +optional

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -58,22 +58,27 @@ type BuildSpec struct {
 	Generation int64 `json:"generation,omitempty"`
 
 	// Source specifies the input to the build.
+	// +optional
 	Source *SourceSpec `json:"source,omitempty"`
 
 	// Steps are the steps of the build; each step is run sequentially with the
 	// source mounted into /workspace.
+	// +optional
 	Steps []corev1.Container `json:"steps,omitempty"`
 
 	// Volumes is a collection of volumes that are available to mount into the
 	// steps of the build.
+	// +optional
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// The name of the service account as which to run this build.
+	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Template, if specified, references a BuildTemplate resource to use to
 	// populate fields in the build, and optional Arguments to pass to the
 	// template. The default Kind of template is BuildTemplate
+	// +optional
 	Template *TemplateInstantiationSpec `json:"template,omitempty"`
 
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
@@ -107,20 +112,22 @@ const (
 // a Build.
 type TemplateInstantiationSpec struct {
 	// Name references the BuildTemplate resource to use.
-	//
 	// The template is assumed to exist in the Build's namespace.
 	Name string `json:"name"`
 
 	// The Kind of the template to be used, possible values are BuildTemplate
 	// or ClusterBuildTemplate. If nothing is specified, the default if is BuildTemplate
+	// +optional
 	Kind TemplateKind `json:"kind,omitempty"`
 
 	// Arguments, if specified, lists values that should be applied to the
 	// parameters specified by the template.
+	// +optional
 	Arguments []ArgumentSpec `json:"arguments,omitempty"`
 
 	// Env, if specified will provide variables to all build template steps.
 	// This will override any of the template's steps environment variables.
+	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
@@ -137,19 +144,23 @@ type ArgumentSpec struct {
 // SourceSpec defines the input to the Build
 type SourceSpec struct {
 	// Git represents source in a Git repository.
+	// +optional
 	Git *GitSourceSpec `json:"git,omitempty"`
 
 	// GCS represents source in Google Cloud Storage.
+	// +optional
 	GCS *GCSSourceSpec `json:"gcs,omitempty"`
 
 	// Custom indicates that source should be retrieved using a custom
 	// process defined in a container invocation.
+	// +optional
 	Custom *corev1.Container `json:"custom,omitempty"`
 
 	// SubPath specifies a path within the fetched source which should be
 	// built. This option makes parent directories *inaccessible* to the
 	// build steps. (The specific source type may, in fact, not even fetch
 	// files not in the SubPath.)
+	// +optional
 	SubPath string `json:"subPath,omitempty"`
 }
 
@@ -198,25 +209,34 @@ const (
 
 // BuildStatus is the status for a Build resource
 type BuildStatus struct {
+	// +optional
 	Builder BuildProvider `json:"builder,omitempty"`
 
 	// Cluster provides additional information if the builder is Cluster.
+	// +optional
 	Cluster *ClusterSpec `json:"cluster,omitempty"`
+
 	// Google provides additional information if the builder is Google.
+	// +optional
 	Google *GoogleSpec `json:"google,omitempty"`
 
 	// StartTime is the time the build is actually started.
+	// +optional
 	StartTime metav1.Time `json:"startTime,omitEmpty"`
+
 	// CompletionTime is the time the build completed.
+	// +optional
 	CompletionTime metav1.Time `json:"completionTime,omitEmpty"`
 
 	// StepStates describes the state of each build step container.
+	// +optional
 	StepStates []corev1.ContainerState `json:"stepStates,omitEmpty"`
 
 	// StepsCompleted lists the name of build steps completed.
 	StepsCompleted []string `json:"stepsCompleted"`
 
 	// Conditions describes the set of conditions of this build.
+	// +optional
 	Conditions duckv1alpha1.Conditions `json:"conditions,omitempty"`
 }
 

--- a/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
@@ -198,8 +198,24 @@ func (in *BuildStatus) DeepCopyInto(out *BuildStatus) {
 			**out = **in
 		}
 	}
-	in.StartTime.DeepCopyInto(&out.StartTime)
-	in.CompletionTime.DeepCopyInto(&out.CompletionTime)
+	if in.StartTime != nil {
+		in, out := &in.StartTime, &out.StartTime
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(meta_v1.Time)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.CompletionTime != nil {
+		in, out := &in.CompletionTime, &out.CompletionTime
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(meta_v1.Time)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	if in.StepStates != nil {
 		in, out := &in.StepStates, &out.StepStates
 		*out = make([]v1.ContainerState, len(*in))

--- a/pkg/builder/cluster/builder.go
+++ b/pkg/builder/cluster/builder.go
@@ -20,6 +20,7 @@ package cluster
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/knative/build/pkg/builder/cluster/convert"
 	"go.uber.org/zap"
@@ -39,7 +40,7 @@ type operation struct {
 	builder   *builder
 	namespace string
 	name      string
-	startTime metav1.Time
+	startTime *metav1.Time
 	statuses  []corev1.ContainerStatus
 }
 
@@ -119,7 +120,7 @@ func (op *operation) Wait() (*v1alpha1.BuildStatus, error) {
 			PodName:   op.Name(),
 		},
 		StartTime:      op.startTime,
-		CompletionTime: metav1.Now(),
+		CompletionTime: &metav1.Time{time.Now()},
 		StepStates:     states,
 		StepsCompleted: stepsCompleted,
 	}
@@ -162,7 +163,7 @@ func (b *build) Execute() (buildercommon.Operation, error) {
 		builder:   b.builder,
 		namespace: pod.Namespace,
 		name:      pod.Name,
-		startTime: metav1.Now(),
+		startTime: &metav1.Time{time.Now()},
 		statuses:  pod.Status.InitContainerStatuses,
 	}, nil
 }

--- a/pkg/builder/nop/builder.go
+++ b/pkg/builder/nop/builder.go
@@ -48,7 +48,7 @@ func (nb *operation) Checkpoint(_ *v1alpha1.Build, status *v1alpha1.BuildStatus)
 		status.Google = &v1alpha1.GoogleSpec{}
 	}
 	status.Google.Operation = nb.Name()
-	status.StartTime = startTime
+	status.StartTime = &startTime
 	status.SetCondition(&duckv1alpha1.Condition{
 		Type:   v1alpha1.BuildSucceeded,
 		Status: corev1.ConditionUnknown,
@@ -68,8 +68,8 @@ func (nb *operation) Wait() (*v1alpha1.BuildStatus, error) {
 		Google: &v1alpha1.GoogleSpec{
 			Operation: nb.Name(),
 		},
-		StartTime:      startTime,
-		CompletionTime: completionTime,
+		StartTime:      &startTime,
+		CompletionTime: &completionTime,
 	}
 
 	if nb.builder.ErrorMessage != "" {

--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -19,6 +19,7 @@ package build
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/knative/build/pkg/builder"
@@ -172,7 +173,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 				Message: timeoutMsg,
 			})
 			// update build completed time
-			build.Status.CompletionTime = metav1.Now()
+			build.Status.CompletionTime = &metav1.Time{time.Now()}
 
 			if _, err := c.updateStatus(build); err != nil {
 				c.Logger.Errorf("Failed to update status for pod: %v", err)

--- a/pkg/reconciler/build/build_test.go
+++ b/pkg/reconciler/build/build_test.go
@@ -317,7 +317,7 @@ func TestBasicFlows(t *testing.T) {
 			t.Errorf("error fetching build: %v", err)
 		}
 		// Update status to current time
-		first.Status.StartTime = metav1.Now()
+		first.Status.StartTime = &metav1.Time{time.Now()}
 
 		if builder.IsDone(&first.Status) {
 			t.Errorf("First IsDone(%d); wanted not done, got done.", idx)
@@ -550,10 +550,7 @@ func TestRunController(t *testing.T) {
 		t.Errorf("error creating build: %v", err)
 	}
 
-	// Ignore build start time when comparing
-	var ignoreTime = cmpopts.IgnoreFields(v1alpha1.Build{}.Status.StartTime.Time)
-
-	if d := cmp.Diff(b, build, ignoreTime); d != "" {
+	if d := cmp.Diff(b, build); d != "" {
 		t.Errorf("Build mismatch; diff: %s; got %v; wanted: %v", d, b, build)
 	}
 


### PR DESCRIPTION
This is recommended api convention by k8s.

Ref: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#optional-vs-required


## Proposed Changes

  * Add `+optional` tags

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
