### PR TITLE
 Move pkg/builder/common* to pkg/reconciler/build/apply*

### DIFF
--- a/pkg/reconciler/build/apply.go
+++ b/pkg/reconciler/build/apply.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package build provides common methods for Builder implementations.
 package build
 
 import (

--- a/pkg/reconciler/build/apply.go
+++ b/pkg/reconciler/build/apply.go
@@ -14,16 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package builder provides common methods for Builder implementations.
-package builder
+// Package build provides common methods for Builder implementations.
+package build
 
 import (
 	"fmt"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/knative/build/pkg/apis/build/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ApplyTemplate applies the values in the template to the build, and replaces

--- a/pkg/reconciler/build/apply_test.go
+++ b/pkg/reconciler/build/apply_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package builder
+package build
 
 import (
 	"reflect"

--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -214,7 +214,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 			}
 		}
 	}
-	build, err = builder.ApplyTemplate(build, tmpl)
+	build, err = ApplyTemplate(build, tmpl)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Another step toward dismantling `pkg/builder/...` -- the only thing that used this was in `pkg/reconciler/build` so we'll just move it there.

## Proposed Changes

  * `mv pkg/builder/common.go pkg/reconciler/build/apply.go` etc.
  * No functional changes.

**Release Note**
```release-note
NONE
```

<!--
/assign shashwathi
/lint
-->
