### PR TITLE
Add e2e test for sources with targetpath

### DIFF
--- a/test/sources/test-gopath.yaml
+++ b/test/sources/test-gopath.yaml
@@ -1,0 +1,38 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: build.knative.dev/v1alpha1
+kind: Build
+metadata:
+  name: gopath-test
+  labels:
+    expect: succeeded
+spec:
+  sources:
+  - name: build-git
+    targetPath: go/src/github.com/knative/build
+    git:
+      url: https://github.com/knative/build
+      revision: master
+  steps:
+  - name: test-build
+    image: golang
+    command: ['go']
+    args:
+    - 'test'
+    - './...'
+    workingDir: "/workspace/go/src/github.com/knative/build"
+    env:
+    - name: GOPATH
+      value: /workspace/go
+


### PR DESCRIPTION
This PR includes e2e test of using `targetPath` in a valid use-case i.e., source copied into targetpath and running go tests.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
