### PR TITLE
Increase timeout for TestSimpleBuild

### DIFF
--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -83,7 +83,7 @@ func TestSimpleBuild(t *testing.T) {
 			Name:      buildName,
 		},
 		Spec: v1alpha1.BuildSpec{
-			Timeout: &metav1.Duration{Duration: 40 * time.Second},
+			Timeout: &metav1.Duration{Duration: 120 * time.Second},
 			Steps: []corev1.Container{{
 				Image: "busybox",
 				Args:  []string{"echo", "simple"},


### PR DESCRIPTION
This test randomly fails on our OpenShift instance due to timeout. I think increasing the timeout to 120 is sufficient in general (it passes constantly in our case).
