### PR TITLE
Fix swapped reason/message when pod is initializing

### DIFF
--- a/pkg/builder/cluster/builder.go
+++ b/pkg/builder/cluster/builder.go
@@ -137,8 +137,8 @@ func (op *operation) Wait() (*v1alpha1.BuildStatus, error) {
 		bs.SetCondition(&duckv1alpha1.Condition{
 			Type:    v1alpha1.BuildSucceeded,
 			Status:  corev1.ConditionUnknown,
-			Message: "Pending",
-			Reason:  msg,
+			Reason:  "Pending",
+			Message: msg,
 		})
 	} else {
 		bs.SetCondition(&duckv1alpha1.Condition{

--- a/pkg/builder/cluster/builder_test.go
+++ b/pkg/builder/cluster/builder_test.go
@@ -624,7 +624,7 @@ func TestBasicFlowWithCredentials(t *testing.T) {
 func statusMessage(status *v1alpha1.BuildStatus) string {
 	for _, cond := range status.Conditions {
 		if cond.Type == v1alpha1.BuildSucceeded && cond.Status == corev1.ConditionUnknown {
-			return cond.Reason
+			return cond.Message
 		}
 	}
 	return ""


### PR DESCRIPTION
Fixes #474 

## Proposed Changes

  * Fixed swapped reason/message when pod is initializing.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
None
```
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
