### PR TITLE
Populate status in case of validation errors 👷

### DIFF
--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -159,6 +159,15 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if build.Status.Cluster == nil || build.Status.Cluster.PodName == "" {
 		if err = c.validateBuild(build); err != nil {
 			logger.Errorf("Failed to validate build: %v", err)
+			build.Status.SetCondition(&duckv1alpha1.Condition{
+				Type:    v1alpha1.BuildSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  "BuildValidationFailed",
+				Message: err.Error(),
+			})
+			if err := c.updateStatus(build); err != nil {
+				return err
+			}
 			return err
 		}
 		p, err = c.startPodForBuild(build)


### PR DESCRIPTION
In case a build has not been yet started (i.e. no Pod), we validate
the build spec and then we create and start the Pod for this build. In
case the validation fail, we return an error and never update the
build status, making it hard to know why it doesn't work.

Fixes #471 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
