### PR TITLE
Fix scripts to install dep-collector when not present

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,6 +120,21 @@
   revision = "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 
 [[projects]]
+  branch = "master"
+  digest = "1:0d5e3798bfa2642ac268341c96710b8def1f3cbc3bc803c421d90704d72107d8"
+  name = "github.com/google/licenseclassifier"
+  packages = [
+    ".",
+    "internal/sets",
+    "stringclassifier",
+    "stringclassifier/internal/pq",
+    "stringclassifier/searchset",
+    "stringclassifier/searchset/tokenizer",
+  ]
+  pruneopts = "NUT"
+  revision = "e979a0b10eebe748549c702a25e997c556349da6"
+
+[[projects]]
   digest = "1:27b4ab41ffdc76ad6db56db327a4db234a59588ef059fc3fd678ba0bc6b9094f"
   name = "github.com/googleapis/gnostic"
   packages = [
@@ -234,9 +249,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0cabae2c3a124c49ed5e862866e1228f08a1a6e49d0daf971e5a72e5e56095a4"
+  digest = "1:7a7aea24f67afa5dedb422fb3592d5a5c3af91b4b9d59eddf06767729915b3c4"
   name = "github.com/knative/test-infra"
-  packages = ["scripts"]
+  packages = [
+    "scripts",
+    "tools/dep-collector",
+  ]
   pruneopts = "UT"
   revision = "2a11b760d21b3a969d80d9ccf18323e1d5ed03a6"
 

--- a/vendor/github.com/google/licenseclassifier/LICENSE
+++ b/vendor/github.com/google/licenseclassifier/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/licenseclassifier/classifier.go
+++ b/vendor/github.com/google/licenseclassifier/classifier.go
@@ -1,0 +1,429 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package licenseclassifier provides methods to identify the open source
+// license that most closely matches an unknown license.
+package licenseclassifier
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"html"
+	"io"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/google/licenseclassifier/stringclassifier"
+	"github.com/google/licenseclassifier/stringclassifier/searchset"
+)
+
+// DefaultConfidenceThreshold is the minimum confidence percentage we're willing to accept in order
+// to say that a match is good.
+const DefaultConfidenceThreshold = 0.80
+
+var (
+	// Normalizers is a list of functions that get applied to the strings
+	// before they are registered with the string classifier.
+	Normalizers = []stringclassifier.NormalizeFunc{
+		html.UnescapeString,
+		removeShebangLine,
+		RemoveNonWords,
+		NormalizeEquivalentWords,
+		NormalizePunctuation,
+		strings.ToLower,
+		removeIgnorableTexts,
+		stringclassifier.FlattenWhitespace,
+		strings.TrimSpace,
+	}
+
+	// commonLicenseWords are words that are common to all known licenses.
+	// If an unknown text doesn't have at least one of these, then we can
+	// ignore it.
+	commonLicenseWords = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\bcode\b`),
+		regexp.MustCompile(`(?i)\blicense\b`),
+		regexp.MustCompile(`(?i)\boriginal\b`),
+		regexp.MustCompile(`(?i)\brights\b`),
+		regexp.MustCompile(`(?i)\bsoftware\b`),
+		regexp.MustCompile(`(?i)\bterms\b`),
+		regexp.MustCompile(`(?i)\bversion\b`),
+		regexp.MustCompile(`(?i)\bwork\b`),
+	}
+)
+
+// License is a classifier pre-loaded with known open source licenses.
+type License struct {
+	c *stringclassifier.Classifier
+
+	// Threshold is the lowest confidence percentage acceptable for the
+	// classifier.
+	Threshold float64
+}
+
+// New creates a license classifier and pre-loads it with known open source licenses.
+func New(threshold float64) (*License, error) {
+	classifier := &License{
+		c:         stringclassifier.New(threshold, Normalizers...),
+		Threshold: threshold,
+	}
+	if err := classifier.registerLicenses(LicenseArchive); err != nil {
+		return nil, fmt.Errorf("cannot register licenses: %v", err)
+	}
+	return classifier, nil
+}
+
+// NewWithForbiddenLicenses creates a license classifier and pre-loads it with
+// known open source licenses which are forbidden.
+func NewWithForbiddenLicenses(threshold float64) (*License, error) {
+	classifier := &License{
+		c:         stringclassifier.New(threshold, Normalizers...),
+		Threshold: threshold,
+	}
+	if err := classifier.registerLicenses(ForbiddenLicenseArchive); err != nil {
+		return nil, fmt.Errorf("cannot register licenses: %v", err)
+	}
+	return classifier, nil
+}
+
+// WithinConfidenceThreshold returns true if the confidence value is above or
+// equal to the confidence threshold.
+func (c *License) WithinConfidenceThreshold(conf float64) bool {
+	return conf > c.Threshold || math.Abs(conf-c.Threshold) < math.SmallestNonzeroFloat64
+}
+
+// NearestMatch returns the "nearest" match to the given set of known licenses.
+// Returned are the name of the license, and a confidence percentage indicating
+// how confident the classifier is in the result.
+func (c *License) NearestMatch(contents string) *stringclassifier.Match {
+	if !c.hasCommonLicenseWords(contents) {
+		return nil
+	}
+	m := c.c.NearestMatch(contents)
+	m.Name = strings.TrimSuffix(m.Name, ".header")
+	return m
+}
+
+// MultipleMatch matches all licenses within an unknown text.
+func (c *License) MultipleMatch(contents string, includeHeaders bool) stringclassifier.Matches {
+	norm := normalizeText(contents)
+	if !c.hasCommonLicenseWords(norm) {
+		return nil
+	}
+
+	m := make(map[stringclassifier.Match]bool)
+	var matches stringclassifier.Matches
+	for _, v := range c.c.MultipleMatch(norm) {
+		if !c.WithinConfidenceThreshold(v.Confidence) {
+			continue
+		}
+
+		if !includeHeaders && strings.HasSuffix(v.Name, ".header") {
+			continue
+		}
+
+		v.Name = strings.TrimSuffix(v.Name, ".header")
+		if re, ok := forbiddenRegexps[v.Name]; ok && !re.MatchString(norm) {
+			continue
+		}
+		if _, ok := m[*v]; !ok {
+			m[*v] = true
+			matches = append(matches, v)
+		}
+	}
+	sort.Sort(matches)
+	return matches
+}
+
+func normalizeText(s string) string {
+	for _, n := range Normalizers {
+		s = n(s)
+	}
+	return s
+}
+
+// hasCommonLicenseWords returns true if the unknown text has at least one word
+// that's common to all licenses.
+func (c *License) hasCommonLicenseWords(s string) bool {
+	for _, re := range commonLicenseWords {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+type archivedValue struct {
+	name       string
+	normalized string
+	set        *searchset.SearchSet
+}
+
+// registerLicenses loads all known licenses and adds them to c as known values
+// for comparison. The allocated space after ingesting the 'licenses.db'
+// archive is ~167M.
+func (c *License) registerLicenses(archive string) error {
+	contents, err := ReadLicenseFile(archive)
+	if err != nil {
+		return err
+	}
+
+	reader := bytes.NewReader(contents)
+	gr, err := gzip.NewReader(reader)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+
+	var muVals sync.Mutex
+	var vals []archivedValue
+	for i := 0; ; i++ {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		name := strings.TrimSuffix(hdr.Name, ".txt")
+
+		// Read normalized value.
+		var b bytes.Buffer
+		if _, err := io.Copy(&b, tr); err != nil {
+			return err
+		}
+		normalized := b.String()
+		b.Reset()
+
+		// Read precomputed hashes.
+		hdr, err = tr.Next()
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(&b, tr); err != nil {
+			return err
+		}
+
+		var set searchset.SearchSet
+		searchset.Deserialize(&b, &set)
+
+		muVals.Lock()
+		vals = append(vals, archivedValue{name, normalized, &set})
+		muVals.Unlock()
+	}
+
+	for _, v := range vals {
+		if err = c.c.AddPrecomputedValue(v.name, v.normalized, v.set); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// endOfLicenseText is text commonly associated with the end of a license. We
+// can remove text that occurs after it.
+var endOfLicenseText = []string{
+	"END OF TERMS AND CONDITIONS",
+}
+
+// TrimExtraneousTrailingText removes text after an obvious end of the license
+// and does not include substantive text of the license.
+func TrimExtraneousTrailingText(s string) string {
+	for _, e := range endOfLicenseText {
+		if i := strings.LastIndex(s, e); i != -1 {
+			return s[:i+len(e)]
+		}
+	}
+	return s
+}
+
+var copyrightRE = regexp.MustCompile(`(?m)(?i:Copyright)\s+(?i:©\s+|\(c\)\s+)?(?:\d{2,4})(?:[-,]\s*\d{2,4})*,?\s*(?i:by)?\s*(.*?(?i:\s+Inc\.)?)[.,]?\s*(?i:All rights reserved\.?)?\s*$`)
+
+// CopyrightHolder finds a copyright notification, if it exists, and returns
+// the copyright holder.
+func CopyrightHolder(contents string) string {
+	matches := copyrightRE.FindStringSubmatch(contents)
+	if len(matches) == 2 {
+		return matches[1]
+	}
+	return ""
+}
+
+var publicDomainRE = regexp.MustCompile("(?i)(this file )?is( in the)? public domain")
+
+// HasPublicDomainNotice performs a simple regex over the contents to see if a
+// public domain notice is in there. As you can imagine, this isn't 100%
+// definitive, but can be useful if a license match isn't found.
+func (c *License) HasPublicDomainNotice(contents string) bool {
+	return publicDomainRE.FindString(contents) != ""
+}
+
+// ignorableTexts is a list of lines at the start of the string we can remove
+// to get a cleaner match.
+var ignorableTexts = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)^(?:the )?mit license(?: \(mit\))?$`),
+	regexp.MustCompile(`(?i)^(?:new )?bsd license$`),
+	regexp.MustCompile(`(?i)^copyright and permission notice$`),
+	regexp.MustCompile(`(?i)^copyright (\(c\) )?(\[yyyy\]|\d{4})[,.]? .*$`),
+	regexp.MustCompile(`(?i)^(all|some) rights reserved\.?$`),
+	regexp.MustCompile(`(?i)^@license$`),
+	regexp.MustCompile(`^\s*$`),
+}
+
+// removeIgnorableTexts removes common text, which is not important for
+// classification, that shows up before the body of the license.
+func removeIgnorableTexts(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	var start int
+	for ; start < len(lines); start++ {
+		line := strings.TrimSpace(lines[start])
+		var matches bool
+		for _, re := range ignorableTexts {
+			if re.MatchString(line) {
+				matches = true
+				break
+			}
+		}
+		if !matches {
+			break
+		}
+	}
+	end := len(lines)
+	if start > end {
+		return "\n"
+	}
+	return strings.Join(lines[start:end], "\n") + "\n"
+}
+
+// removeShebangLine removes the '#!...' line if it's the first line in the
+// file. Note that if it's the only line in a comment, it won't be removed.
+func removeShebangLine(s string) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) <= 1 || !strings.HasPrefix(lines[0], "#!") {
+		return s
+	}
+
+	return strings.Join(lines[1:], "\n")
+}
+
+// isDecorative returns true if the line is made up purely of non-letter and
+// non-digit characters.
+func isDecorative(s string) bool {
+	for _, c := range s {
+		if unicode.IsLetter(c) || unicode.IsDigit(c) {
+			return false
+		}
+	}
+	return true
+}
+
+var nonWords = regexp.MustCompile("[[:punct:]]+")
+
+// RemoveNonWords removes non-words from the string.
+func RemoveNonWords(s string) string {
+	return nonWords.ReplaceAllString(s, " ")
+}
+
+// interchangeablePunctutation is punctuation that can be normalized.
+var interchangeablePunctuation = []struct {
+	interchangeable *regexp.Regexp
+	substitute      string
+}{
+	// Hyphen, Dash, En Dash, and Em Dash.
+	{regexp.MustCompile(`[-‒–—]`), "-"},
+	// Single, Double, Curly Single, and Curly Double.
+	{regexp.MustCompile("['\"`‘’“”]"), "'"},
+	// Copyright.
+	{regexp.MustCompile("©"), "(c)"},
+	// Hyphen-separated words.
+	{regexp.MustCompile(`(\S)-\s+(\S)`), "${1}-${2}"},
+	// Currency and Section. (Different copies of the CDDL use each marker.)
+	{regexp.MustCompile("[§¤]"), "(s)"},
+	// Middle Dot
+	{regexp.MustCompile("·"), "*"},
+}
+
+// NormalizePunctuation takes all hyphens and quotes and normalizes them.
+func NormalizePunctuation(s string) string {
+	for _, iw := range interchangeablePunctuation {
+		s = iw.interchangeable.ReplaceAllString(s, iw.substitute)
+	}
+	return s
+}
+
+// interchangeableWords are words we can substitute for a normalized form
+// without changing the meaning of the license. See
+// https://spdx.org/spdx-license-list/matching-guidelines for the list.
+var interchangeableWords = []struct {
+	interchangeable *regexp.Regexp
+	substitute      string
+}{
+	{regexp.MustCompile("(?i)Acknowledgment"), "Acknowledgement"},
+	{regexp.MustCompile("(?i)Analogue"), "Analog"},
+	{regexp.MustCompile("(?i)Analyse"), "Analyze"},
+	{regexp.MustCompile("(?i)Artefact"), "Artifact"},
+	{regexp.MustCompile("(?i)Authorisation"), "Authorization"},
+	{regexp.MustCompile("(?i)Authorised"), "Authorized"},
+	{regexp.MustCompile("(?i)Calibre"), "Caliber"},
+	{regexp.MustCompile("(?i)Cancelled"), "Canceled"},
+	{regexp.MustCompile("(?i)Capitalisations"), "Capitalizations"},
+	{regexp.MustCompile("(?i)Catalogue"), "Catalog"},
+	{regexp.MustCompile("(?i)Categorise"), "Categorize"},
+	{regexp.MustCompile("(?i)Centre"), "Center"},
+	{regexp.MustCompile("(?i)Emphasised"), "Emphasized"},
+	{regexp.MustCompile("(?i)Favour"), "Favor"},
+	{regexp.MustCompile("(?i)Favourite"), "Favorite"},
+	{regexp.MustCompile("(?i)Fulfil"), "Fulfill"},
+	{regexp.MustCompile("(?i)Fulfilment"), "Fulfillment"},
+	{regexp.MustCompile("(?i)Initialise"), "Initialize"},
+	{regexp.MustCompile("(?i)Judgment"), "Judgement"},
+	{regexp.MustCompile("(?i)Labelling"), "Labeling"},
+	{regexp.MustCompile("(?i)Labour"), "Labor"},
+	{regexp.MustCompile("(?i)Licence"), "License"},
+	{regexp.MustCompile("(?i)Maximise"), "Maximize"},
+	{regexp.MustCompile("(?i)Modelled"), "Modeled"},
+	{regexp.MustCompile("(?i)Modelling"), "Modeling"},
+	{regexp.MustCompile("(?i)Offence"), "Offense"},
+	{regexp.MustCompile("(?i)Optimise"), "Optimize"},
+	{regexp.MustCompile("(?i)Organisation"), "Organization"},
+	{regexp.MustCompile("(?i)Organise"), "Organize"},
+	{regexp.MustCompile("(?i)Practise"), "Practice"},
+	{regexp.MustCompile("(?i)Programme"), "Program"},
+	{regexp.MustCompile("(?i)Realise"), "Realize"},
+	{regexp.MustCompile("(?i)Recognise"), "Recognize"},
+	{regexp.MustCompile("(?i)Signalling"), "Signaling"},
+	{regexp.MustCompile("(?i)Sub[- ]license"), "Sublicense"},
+	{regexp.MustCompile("(?i)Utilisation"), "Utilization"},
+	{regexp.MustCompile("(?i)Whilst"), "While"},
+	{regexp.MustCompile("(?i)Wilful"), "Wilfull"},
+	{regexp.MustCompile("(?i)Non-commercial"), "Noncommercial"},
+	{regexp.MustCompile("(?i)Per cent"), "Percent"},
+}
+
+// NormalizeEquivalentWords normalizes equivalent words that are interchangeable.
+func NormalizeEquivalentWords(s string) string {
+	for _, iw := range interchangeableWords {
+		s = iw.interchangeable.ReplaceAllString(s, iw.substitute)
+	}
+	return s
+}

--- a/vendor/github.com/google/licenseclassifier/file_system_resources.go
+++ b/vendor/github.com/google/licenseclassifier/file_system_resources.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package licenseclassifier
+
+import (
+	"go/build"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// LicenseDirectory is the directory where the prototype licenses are kept.
+	LicenseDirectory = "src/github.com/google/licenseclassifier/licenses"
+	// LicenseArchive is the name of the archive containing preprocessed
+	// license texts.
+	LicenseArchive = "licenses.db"
+	// ForbiddenLicenseArchive is the name of the archive containing preprocessed
+	// forbidden license texts only.
+	ForbiddenLicenseArchive = "forbidden_licenses.db"
+)
+
+func findInGOPATH(rel string) (fullPath string, err error) {
+	for _, path := range filepath.SplitList(build.Default.GOPATH) {
+		fullPath := filepath.Join(path, rel)
+		if _, err := os.Stat(fullPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		return fullPath, nil
+	}
+	return "", nil
+}
+
+// ReadLicenseFile locates and reads the license file.
+func ReadLicenseFile(filename string) ([]byte, error) {
+	archive, err := findInGOPATH(filepath.Join(LicenseDirectory, filename))
+	if err != nil || archive == "" {
+		return nil, err
+	}
+	return ioutil.ReadFile(archive)
+}
+
+// ReadLicenseDir reads directory containing the license files.
+func ReadLicenseDir() ([]os.FileInfo, error) {
+	filename, err := findInGOPATH(filepath.Join(LicenseDirectory, LicenseArchive))
+	if err != nil || filename == "" {
+		return nil, err
+	}
+	return ioutil.ReadDir(filepath.Dir(filename))
+}

--- a/vendor/github.com/google/licenseclassifier/forbidden.go
+++ b/vendor/github.com/google/licenseclassifier/forbidden.go
@@ -1,0 +1,48 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package licenseclassifier
+
+import "regexp"
+
+var (
+	reCCBYNC   = regexp.MustCompile(`(?i).*\bAttribution NonCommercial\b.*`)
+	reCCBYNCND = regexp.MustCompile(`(?i).*\bAttribution NonCommercial NoDerivs\b.*`)
+	reCCBYNCSA = regexp.MustCompile(`(?i).*\bAttribution NonCommercial ShareAlike\b.*`)
+
+	// forbiddenRegexps are regular expressions we expect to find in
+	// forbidden licenses. If we think we have a forbidden license but
+	// don't find the equivalent phrase, then it's probably just a
+	// misclassification.
+	forbiddenRegexps = map[string]*regexp.Regexp{
+		AGPL10:     regexp.MustCompile(`(?i).*\bAFFERO GENERAL PUBLIC LICENSE\b.*`),
+		AGPL30:     regexp.MustCompile(`(?i).*\bGNU AFFERO GENERAL PUBLIC LICENSE\b.*`),
+		CCBYNC10:   reCCBYNC,
+		CCBYNC20:   reCCBYNC,
+		CCBYNC25:   reCCBYNC,
+		CCBYNC30:   reCCBYNC,
+		CCBYNC40:   reCCBYNC,
+		CCBYNCND10: regexp.MustCompile(`(?i).*\bAttribution NoDerivs NonCommercial\b.*`),
+		CCBYNCND20: reCCBYNCND,
+		CCBYNCND25: reCCBYNCND,
+		CCBYNCND30: reCCBYNCND,
+		CCBYNCND40: regexp.MustCompile(`(?i).*\bAttribution NonCommercial NoDerivatives\b.*`),
+		CCBYNCSA10: reCCBYNCSA,
+		CCBYNCSA20: reCCBYNCSA,
+		CCBYNCSA25: reCCBYNCSA,
+		CCBYNCSA30: reCCBYNCSA,
+		CCBYNCSA40: reCCBYNCSA,
+		WTFPL:      regexp.MustCompile(`(?i).*\bDO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE\b.*`),
+	}
+)

--- a/vendor/github.com/google/licenseclassifier/internal/sets/sets.go
+++ b/vendor/github.com/google/licenseclassifier/internal/sets/sets.go
@@ -1,0 +1,20 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sets provides sets for storing collections of unique elements.
+package sets
+
+// present is an empty struct used as the "value" in the map[int], since
+// empty structs consume zero bytes (unlike 1 unnecessary byte per bool).
+type present struct{}

--- a/vendor/github.com/google/licenseclassifier/internal/sets/stringset.go
+++ b/vendor/github.com/google/licenseclassifier/internal/sets/stringset.go
@@ -1,0 +1,228 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sets
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// StringSet stores a set of unique string elements.
+type StringSet struct {
+	set map[string]present
+}
+
+// NewStringSet creates a StringSet containing the supplied initial string elements.
+func NewStringSet(elements ...string) *StringSet {
+	s := &StringSet{}
+	s.set = make(map[string]present)
+	s.Insert(elements...)
+	return s
+}
+
+// Copy returns a newly allocated copy of the supplied StringSet.
+func (s *StringSet) Copy() *StringSet {
+	c := NewStringSet()
+	if s != nil {
+		for e := range s.set {
+			c.set[e] = present{}
+		}
+	}
+	return c
+}
+
+// Insert zero or more string elements into the StringSet.
+// As expected for a Set, elements already present in the StringSet are
+// simply ignored.
+func (s *StringSet) Insert(elements ...string) {
+	for _, e := range elements {
+		s.set[e] = present{}
+	}
+}
+
+// Delete zero or more string elements from the StringSet.
+// Any elements not present in the StringSet are simply ignored.
+func (s *StringSet) Delete(elements ...string) {
+	for _, e := range elements {
+		delete(s.set, e)
+	}
+}
+
+// Intersect returns a new StringSet containing the intersection of the
+// receiver and argument StringSets.  Returns an empty set if the argument is nil.
+func (s *StringSet) Intersect(other *StringSet) *StringSet {
+	if other == nil {
+		return NewStringSet()
+	}
+
+	// Point a and b to the maps, setting a to the smaller of the two.
+	a, b := s.set, other.set
+	if len(b) < len(a) {
+		a, b = b, a
+	}
+
+	// Perform the intersection.
+	intersect := NewStringSet()
+	for e := range a {
+		if _, ok := b[e]; ok {
+			intersect.set[e] = present{}
+		}
+	}
+	return intersect
+}
+
+// Disjoint returns true if the intersection of the receiver and the argument
+// StringSets is the empty set.  Returns true if the argument is nil or either
+// StringSet is the empty set.
+func (s *StringSet) Disjoint(other *StringSet) bool {
+	if other == nil || len(other.set) == 0 || len(s.set) == 0 {
+		return true
+	}
+
+	// Point a and b to the maps, setting a to the smaller of the two.
+	a, b := s.set, other.set
+	if len(b) < len(a) {
+		a, b = b, a
+	}
+
+	// Check for non-empty intersection.
+	for e := range a {
+		if _, ok := b[e]; ok {
+			return false // Early-exit because intersecting.
+		}
+	}
+	return true
+}
+
+// Difference returns a new StringSet containing the elements in the receiver
+// that are not present in the argument StringSet. Returns a copy of the
+// receiver if the argument is nil.
+func (s *StringSet) Difference(other *StringSet) *StringSet {
+	if other == nil {
+		return s.Copy()
+	}
+
+	// Insert only the elements in the receiver that are not present in the
+	// argument StringSet.
+	diff := NewStringSet()
+	for e := range s.set {
+		if _, ok := other.set[e]; !ok {
+			diff.set[e] = present{}
+		}
+	}
+	return diff
+}
+
+// Unique returns a new StringSet containing the elements in the receiver
+// that are not present in the argument StringSet *and* the elements in the
+// argument StringSet that are not in the receiver (which is the union of two
+// disjoint sets). Returns a copy of the
+// receiver if the argument is nil.
+func (s *StringSet) Unique(other *StringSet) *StringSet {
+	if other == nil {
+		return s.Copy()
+	}
+
+	sNotInOther := s.Difference(other)
+	otherNotInS := other.Difference(s)
+
+	// Duplicate Union implementation here to avoid extra Copy, since both
+	// sNotInOther and otherNotInS are already copies.
+	unique := sNotInOther
+	for e := range otherNotInS.set {
+		unique.set[e] = present{}
+	}
+	return unique
+}
+
+// Equal returns true if the receiver and the argument StringSet contain
+// exactly the same elements.
+func (s *StringSet) Equal(other *StringSet) bool {
+	if s == nil || other == nil {
+		return s == nil && other == nil
+	}
+
+	// Two sets of different length cannot have the exact same unique elements.
+	if len(s.set) != len(other.set) {
+		return false
+	}
+
+	// Only one loop is needed. If the two sets are known to be of equal
+	// length, then the two sets are equal only if exactly all of the elements
+	// in the first set are found in the second.
+	for e := range s.set {
+		if _, ok := other.set[e]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Union returns a new StringSet containing the union of the receiver and
+// argument StringSets.  Returns a copy of the receiver if the argument is nil.
+func (s *StringSet) Union(other *StringSet) *StringSet {
+	union := s.Copy()
+	if other != nil {
+		for e := range other.set {
+			union.set[e] = present{}
+		}
+	}
+	return union
+}
+
+// Contains returns true if element is in the StringSet.
+func (s *StringSet) Contains(element string) bool {
+	_, in := s.set[element]
+	return in
+}
+
+// Len returns the number of unique elements in the StringSet.
+func (s *StringSet) Len() int {
+	return len(s.set)
+}
+
+// Empty returns true if the receiver is the empty set.
+func (s *StringSet) Empty() bool {
+	return len(s.set) == 0
+}
+
+// Elements returns a []string of the elements in the StringSet, in no
+// particular (or consistent) order.
+func (s *StringSet) Elements() []string {
+	elements := []string{} // Return at least an empty slice rather than nil.
+	for e := range s.set {
+		elements = append(elements, e)
+	}
+	return elements
+}
+
+// Sorted returns a sorted []string of the elements in the StringSet.
+func (s *StringSet) Sorted() []string {
+	elements := s.Elements()
+	sort.Strings(elements)
+	return elements
+}
+
+// String formats the StringSet elements as sorted strings, representing them
+// in "array initializer" syntax.
+func (s *StringSet) String() string {
+	elements := s.Sorted()
+	var quoted []string
+	for _, e := range elements {
+		quoted = append(quoted, fmt.Sprintf("%q", e))
+	}
+	return fmt.Sprintf("{%s}", strings.Join(quoted, ", "))
+}

--- a/vendor/github.com/google/licenseclassifier/license_type.go
+++ b/vendor/github.com/google/licenseclassifier/license_type.go
@@ -1,0 +1,375 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package licenseclassifier
+
+// *** NOTE: Update this file when adding a new license. You need to:
+//
+//   1. Add the canonical name to the list, and
+//   2. Categorize the license.
+
+import "github.com/google/licenseclassifier/internal/sets"
+
+// Canonical names of the licenses.
+const (
+	// The names come from the https://spdx.org/licenses website, and are
+	// also the filenames of the licenses in licenseclassifier/licenses.
+	AFL11                       = "AFL-1.1"
+	AFL12                       = "AFL-1.2"
+	AFL20                       = "AFL-2.0"
+	AFL21                       = "AFL-2.1"
+	AFL30                       = "AFL-3.0"
+	AGPL10                      = "AGPL-1.0"
+	AGPL30                      = "AGPL-3.0"
+	Apache10                    = "Apache-1.0"
+	Apache11                    = "Apache-1.1"
+	Apache20                    = "Apache-2.0"
+	APSL10                      = "APSL-1.0"
+	APSL11                      = "APSL-1.1"
+	APSL12                      = "APSL-1.2"
+	APSL20                      = "APSL-2.0"
+	Artistic10cl8               = "Artistic-1.0-cl8"
+	Artistic10Perl              = "Artistic-1.0-Perl"
+	Artistic10                  = "Artistic-1.0"
+	Artistic20                  = "Artistic-2.0"
+	BCL                         = "BCL"
+	Beerware                    = "Beerware"
+	BSD2ClauseFreeBSD           = "BSD-2-Clause-FreeBSD"
+	BSD2ClauseNetBSD            = "BSD-2-Clause-NetBSD"
+	BSD2Clause                  = "BSD-2-Clause"
+	BSD3ClauseAttribution       = "BSD-3-Clause-Attribution"
+	BSD3ClauseClear             = "BSD-3-Clause-Clear"
+	BSD3ClauseLBNL              = "BSD-3-Clause-LBNL"
+	BSD3Clause                  = "BSD-3-Clause"
+	BSD4Clause                  = "BSD-4-Clause"
+	BSD4ClauseUC                = "BSD-4-Clause-UC"
+	BSDProtection               = "BSD-Protection"
+	BSL10                       = "BSL-1.0"
+	CC010                       = "CC0-1.0"
+	CCBY10                      = "CC-BY-1.0"
+	CCBY20                      = "CC-BY-2.0"
+	CCBY25                      = "CC-BY-2.5"
+	CCBY30                      = "CC-BY-3.0"
+	CCBY40                      = "CC-BY-4.0"
+	CCBYNC10                    = "CC-BY-NC-1.0"
+	CCBYNC20                    = "CC-BY-NC-2.0"
+	CCBYNC25                    = "CC-BY-NC-2.5"
+	CCBYNC30                    = "CC-BY-NC-3.0"
+	CCBYNC40                    = "CC-BY-NC-4.0"
+	CCBYNCND10                  = "CC-BY-NC-ND-1.0"
+	CCBYNCND20                  = "CC-BY-NC-ND-2.0"
+	CCBYNCND25                  = "CC-BY-NC-ND-2.5"
+	CCBYNCND30                  = "CC-BY-NC-ND-3.0"
+	CCBYNCND40                  = "CC-BY-NC-ND-4.0"
+	CCBYNCSA10                  = "CC-BY-NC-SA-1.0"
+	CCBYNCSA20                  = "CC-BY-NC-SA-2.0"
+	CCBYNCSA25                  = "CC-BY-NC-SA-2.5"
+	CCBYNCSA30                  = "CC-BY-NC-SA-3.0"
+	CCBYNCSA40                  = "CC-BY-NC-SA-4.0"
+	CCBYND10                    = "CC-BY-ND-1.0"
+	CCBYND20                    = "CC-BY-ND-2.0"
+	CCBYND25                    = "CC-BY-ND-2.5"
+	CCBYND30                    = "CC-BY-ND-3.0"
+	CCBYND40                    = "CC-BY-ND-4.0"
+	CCBYSA10                    = "CC-BY-SA-1.0"
+	CCBYSA20                    = "CC-BY-SA-2.0"
+	CCBYSA25                    = "CC-BY-SA-2.5"
+	CCBYSA30                    = "CC-BY-SA-3.0"
+	CCBYSA40                    = "CC-BY-SA-4.0"
+	CDDL10                      = "CDDL-1.0"
+	CDDL11                      = "CDDL-1.1"
+	CommonsClause               = "Commons-Clause"
+	CPAL10                      = "CPAL-1.0"
+	CPL10                       = "CPL-1.0"
+	eGenix                      = "eGenix"
+	EPL10                       = "EPL-1.0"
+	EUPL10                      = "EUPL-1.0"
+	EUPL11                      = "EUPL-1.1"
+	Facebook2Clause             = "Facebook-2-Clause"
+	Facebook3Clause             = "Facebook-3-Clause"
+	FacebookExamples            = "Facebook-Examples"
+	FreeImage                   = "FreeImage"
+	FTL                         = "FTL"
+	GPL10                       = "GPL-1.0"
+	GPL20                       = "GPL-2.0"
+	GPL20withautoconfexception  = "GPL-2.0-with-autoconf-exception"
+	GPL20withbisonexception     = "GPL-2.0-with-bison-exception"
+	GPL20withclasspathexception = "GPL-2.0-with-classpath-exception"
+	GPL20withfontexception      = "GPL-2.0-with-font-exception"
+	GPL20withGCCexception       = "GPL-2.0-with-GCC-exception"
+	GPL30                       = "GPL-3.0"
+	GPL30withautoconfexception  = "GPL-3.0-with-autoconf-exception"
+	GPL30withGCCexception       = "GPL-3.0-with-GCC-exception"
+	GUSTFont                    = "GUST-Font-License"
+	ImageMagick                 = "ImageMagick"
+	IPL10                       = "IPL-1.0"
+	ISC                         = "ISC"
+	LGPL20                      = "LGPL-2.0"
+	LGPL21                      = "LGPL-2.1"
+	LGPL30                      = "LGPL-3.0"
+	LGPLLR                      = "LGPLLR"
+	Libpng                      = "Libpng"
+	Lil10                       = "Lil-1.0"
+	LPL102                      = "LPL-1.02"
+	LPL10                       = "LPL-1.0"
+	LPPL13c                     = "LPPL-1.3c"
+	MIT                         = "MIT"
+	MPL10                       = "MPL-1.0"
+	MPL11                       = "MPL-1.1"
+	MPL20                       = "MPL-2.0"
+	MSPL                        = "MS-PL"
+	NCSA                        = "NCSA"
+	NPL10                       = "NPL-1.0"
+	NPL11                       = "NPL-1.1"
+	OFL                         = "OFL"
+	OpenSSL                     = "OpenSSL"
+	OSL10                       = "OSL-1.0"
+	OSL11                       = "OSL-1.1"
+	OSL20                       = "OSL-2.0"
+	OSL21                       = "OSL-2.1"
+	OSL30                       = "OSL-3.0"
+	PHP301                      = "PHP-3.01"
+	PHP30                       = "PHP-3.0"
+	PIL                         = "PIL"
+	Python20complete            = "Python-2.0-complete"
+	Python20                    = "Python-2.0"
+	QPL10                       = "QPL-1.0"
+	Ruby                        = "Ruby"
+	SGIB10                      = "SGI-B-1.0"
+	SGIB11                      = "SGI-B-1.1"
+	SGIB20                      = "SGI-B-2.0"
+	SISSL12                     = "SISSL-1.2"
+	SISSL                       = "SISSL"
+	Sleepycat                   = "Sleepycat"
+	UnicodeTOU                  = "Unicode-TOU"
+	Unlicense                   = "Unlicense"
+	W3C19980720                 = "W3C-19980720"
+	W3C                         = "W3C"
+	WTFPL                       = "WTFPL"
+	X11                         = "X11"
+	Xnet                        = "Xnet"
+	Zend20                      = "Zend-2.0"
+	ZlibAcknowledgement         = "zlib-acknowledgement"
+	Zlib                        = "Zlib"
+	ZPL11                       = "ZPL-1.1"
+	ZPL20                       = "ZPL-2.0"
+	ZPL21                       = "ZPL-2.1"
+)
+
+var (
+	// Licenses Categorized by Type
+
+	// restricted - Licenses in this category require mandatory source
+	// distribution if we ships a product that includes third-party code
+	// protected by such a license.
+	restrictedType = sets.NewStringSet(
+		BCL,
+		CCBYND10,
+		CCBYND20,
+		CCBYND25,
+		CCBYND30,
+		CCBYND40,
+		CCBYSA10,
+		CCBYSA20,
+		CCBYSA25,
+		CCBYSA30,
+		CCBYSA40,
+		GPL10,
+		GPL20,
+		GPL20withautoconfexception,
+		GPL20withbisonexception,
+		GPL20withclasspathexception,
+		GPL20withfontexception,
+		GPL20withGCCexception,
+		GPL30,
+		GPL30withautoconfexception,
+		GPL30withGCCexception,
+		LGPL20,
+		LGPL21,
+		LGPL30,
+		NPL10,
+		NPL11,
+		OSL10,
+		OSL11,
+		OSL20,
+		OSL21,
+		OSL30,
+		QPL10,
+		Sleepycat,
+	)
+
+	// reciprocal - These licenses allow usage of software made available
+	// under such licenses freely in *unmodified* form. If the third-party
+	// source code is modified in any way these modifications to the
+	// original third-party source code must be made available.
+	reciprocalType = sets.NewStringSet(
+		APSL10,
+		APSL11,
+		APSL12,
+		APSL20,
+		CDDL10,
+		CDDL11,
+		CPL10,
+		EPL10,
+		FreeImage,
+		IPL10,
+		MPL10,
+		MPL11,
+		MPL20,
+		Ruby,
+	)
+
+	// notice - These licenses contain few restrictions, allowing original
+	// or modified third-party software to be shipped in any product
+	// without endangering or encumbering our source code. All of the
+	// licenses in this category do, however, have an "original Copyright
+	// notice" or "advertising clause", wherein any external distributions
+	// must include the notice or clause specified in the license.
+	noticeType = sets.NewStringSet(
+		AFL11,
+		AFL12,
+		AFL20,
+		AFL21,
+		AFL30,
+		Apache10,
+		Apache11,
+		Apache20,
+		Artistic10cl8,
+		Artistic10Perl,
+		Artistic10,
+		Artistic20,
+		BSL10,
+		BSD2ClauseFreeBSD,
+		BSD2ClauseNetBSD,
+		BSD2Clause,
+		BSD3ClauseAttribution,
+		BSD3ClauseClear,
+		BSD3ClauseLBNL,
+		BSD3Clause,
+		BSD4Clause,
+		BSD4ClauseUC,
+		BSDProtection,
+		CCBY10,
+		CCBY20,
+		CCBY25,
+		CCBY30,
+		CCBY40,
+		FTL,
+		ISC,
+		ImageMagick,
+		Libpng,
+		Lil10,
+		LPL102,
+		LPL10,
+		MSPL,
+		MIT,
+		NCSA,
+		OpenSSL,
+		PHP301,
+		PHP30,
+		PIL,
+		Python20,
+		Python20complete,
+		SGIB10,
+		SGIB11,
+		SGIB20,
+		UnicodeTOU,
+		W3C19980720,
+		W3C,
+		X11,
+		Xnet,
+		Zend20,
+		ZlibAcknowledgement,
+		Zlib,
+		ZPL11,
+		ZPL20,
+		ZPL21,
+	)
+
+	// permissive - These licenses can be used in (relatively rare) cases
+	// where third-party software is under a license (not "Public Domain"
+	// or "free for any use" like 'unencumbered') that is even more lenient
+	// than a 'notice' license. Use the 'permissive' license type when even
+	// a copyright notice is not required for license compliance.
+	permissiveType = sets.NewStringSet()
+
+	// unencumbered - Licenses that basically declare that the code is "free for any use".
+	unencumberedType = sets.NewStringSet(
+		CC010,
+		Unlicense,
+	)
+
+	// byexceptiononly - Licenses that are incompatible with all (or most)
+	// uses in combination with our source code. Commercial third-party
+	// packages that are purchased and licensed only for a specific use
+	// fall into this category.
+	byExceptionOnlyType = sets.NewStringSet(
+		Beerware,
+	)
+
+	// forbidden - Licenses that are forbidden to be used.
+	forbiddenType = sets.NewStringSet(
+		AGPL10,
+		AGPL30,
+		CCBYNC10,
+		CCBYNC20,
+		CCBYNC25,
+		CCBYNC30,
+		CCBYNC40,
+		CCBYNCND10,
+		CCBYNCND20,
+		CCBYNCND25,
+		CCBYNCND30,
+		CCBYNCND40,
+		CCBYNCSA10,
+		CCBYNCSA20,
+		CCBYNCSA25,
+		CCBYNCSA30,
+		CCBYNCSA40,
+		CommonsClause,
+		Facebook2Clause,
+		Facebook3Clause,
+		FacebookExamples,
+		WTFPL,
+	)
+
+	// LicenseTypes is a set of the types of licenses Google recognizes.
+	LicenseTypes = sets.NewStringSet(
+		"restricted",
+		"reciprocal",
+		"notice",
+		"permissive",
+		"unencumbered",
+		"by_exception_only",
+	)
+)
+
+// LicenseType returns the type the license has.
+func LicenseType(name string) string {
+	switch {
+	case restrictedType.Contains(name):
+		return "restricted"
+	case reciprocalType.Contains(name):
+		return "reciprocal"
+	case noticeType.Contains(name):
+		return "notice"
+	case permissiveType.Contains(name):
+		return "permissive"
+	case unencumberedType.Contains(name):
+		return "unencumbered"
+	case forbiddenType.Contains(name):
+		return "FORBIDDEN"
+	}
+	return ""
+}

--- a/vendor/github.com/google/licenseclassifier/licenses/Unlicense.txt
+++ b/vendor/github.com/google/licenseclassifier/licenses/Unlicense.txt
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+this software, either in source code form or as a compiled binary, for any
+purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and
+
+successors. We intend this dedication to be an overt act of relinquishment in
+perpetuity of all present and future rights to this software under copyright
+law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+

--- a/vendor/github.com/google/licenseclassifier/stringclassifier/LICENSE
+++ b/vendor/github.com/google/licenseclassifier/stringclassifier/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/licenseclassifier/stringclassifier/classifier.go
+++ b/vendor/github.com/google/licenseclassifier/stringclassifier/classifier.go
@@ -1,0 +1,560 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stringclassifier finds the nearest match between a string and a set of known values. It
+// uses the Levenshtein Distance (LD) algorithm to determine this. A match with a large LD is less
+// likely to be correct than one with a small LD. A confidence percentage is returned, which
+// indicates how confident the algorithm is that the match is correct. The higher the percentage,
+// the greater the confidence that the match is correct.
+//
+// Example Usage:
+//
+//   type Text struct {
+//     Name string
+//     Text string
+//   }
+//
+//   func NewClassifier(knownTexts []Text) (*stringclassifier.Classifier, error) {
+//     sc := stringclassifier.New(stringclassifier.FlattenWhitespace)
+//     for _, known := range knownTexts {
+//       if err := sc.AddValue(known.Name, known.Text); err != nil {
+//         return nil, err
+//       }
+//     }
+//     return sc, nil
+//   }
+//
+//   func IdentifyTexts(sc *stringclassifier.Classifier, unknownTexts []*Text) {
+//     for _, unknown := range unknownTexts {
+//       m := sc.NearestMatch(unknown.Text)
+//       log.Printf("The nearest match to %q is %q (confidence: %v)",
+//         unknown.Name, m.Name, m.Confidence)
+//     }
+//   }
+package stringclassifier
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"regexp"
+	"sort"
+	"sync"
+
+	"github.com/google/licenseclassifier/stringclassifier/internal/pq"
+	"github.com/google/licenseclassifier/stringclassifier/searchset"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+// The diff/match/patch algorithm.
+var dmp = diffmatchpatch.New()
+
+const (
+	// DefaultConfidenceThreshold is the minimum ratio threshold between
+	// the matching range and the full source range that we're willing to
+	// accept in order to say that the matching range will produce a
+	// sufficiently good edit distance. I.e., if the matching range is
+	// below this threshold we won't run the Levenshtein Distance algorithm
+	// on it.
+	DefaultConfidenceThreshold float64 = 0.80
+
+	defaultMinDiffRatio float64 = 0.75
+)
+
+// A Classifier matches a string to a set of known values.
+type Classifier struct {
+	muValues    sync.RWMutex
+	values      map[string]*knownValue
+	normalizers []NormalizeFunc
+	threshold   float64
+
+	// MinDiffRatio defines the minimum ratio of the length difference
+	// allowed to consider a known value a possible match. This is used as
+	// a performance optimization to eliminate values that are unlikely to
+	// be a match.
+	//
+	// For example, a value of 0.75 means that the shorter string must be
+	// at least 75% the length of the longer string to consider it a
+	// possible match.
+	//
+	// Setting this to 1.0 will require that strings are identical length.
+	// Setting this to 0 will consider all known values as possible
+	// matches.
+	MinDiffRatio float64
+}
+
+// NormalizeFunc is a function that is used to normalize a string prior to comparison.
+type NormalizeFunc func(string) string
+
+// New creates a new Classifier with the provided NormalizeFuncs. Each
+// NormalizeFunc is applied in order to a string before comparison.
+func New(threshold float64, funcs ...NormalizeFunc) *Classifier {
+	return &Classifier{
+		values:       make(map[string]*knownValue),
+		normalizers:  append([]NormalizeFunc(nil), funcs...),
+		threshold:    threshold,
+		MinDiffRatio: defaultMinDiffRatio,
+	}
+}
+
+// knownValue identifies a value in the corpus to match against.
+type knownValue struct {
+	key             string
+	normalizedValue string
+	reValue         *regexp.Regexp
+	set             *searchset.SearchSet
+}
+
+// AddValue adds a known value to be matched against. If a value already exists
+// for key, an error is returned.
+func (c *Classifier) AddValue(key, value string) error {
+	c.muValues.Lock()
+	defer c.muValues.Unlock()
+	if _, ok := c.values[key]; ok {
+		return fmt.Errorf("value already registered with key %q", key)
+	}
+	norm := c.normalize(value)
+	c.values[key] = &knownValue{
+		key:             key,
+		normalizedValue: norm,
+		reValue:         regexp.MustCompile(norm),
+	}
+	return nil
+}
+
+// AddPrecomputedValue adds a known value to be matched against. The value has
+// already been normalized and the SearchSet object deserialized, so no
+// processing is necessary.
+func (c *Classifier) AddPrecomputedValue(key, value string, set *searchset.SearchSet) error {
+	c.muValues.Lock()
+	defer c.muValues.Unlock()
+	if _, ok := c.values[key]; ok {
+		return fmt.Errorf("value already registered with key %q", key)
+	}
+	set.GenerateNodeList()
+	c.values[key] = &knownValue{
+		key:             key,
+		normalizedValue: value,
+		reValue:         regexp.MustCompile(value),
+		set:             set,
+	}
+	return nil
+}
+
+// normalize a string by applying each of the registered NormalizeFuncs.
+func (c *Classifier) normalize(s string) string {
+	for _, fn := range c.normalizers {
+		s = fn(s)
+	}
+	return s
+}
+
+// Match identifies the result of matching a string against a knownValue.
+type Match struct {
+	Name       string  // Name of knownValue that was matched
+	Confidence float64 // Confidence percentage
+	Offset     int     // The offset into the unknown string the match was made
+	Extent     int     // The length from the offset into the unknown string
+}
+
+// Matches is a list of Match-es. This is here mainly so that the list can be
+// sorted.
+type Matches []*Match
+
+func (m Matches) Len() int      { return len(m) }
+func (m Matches) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
+func (m Matches) Less(i, j int) bool {
+	if math.Abs(m[j].Confidence-m[i].Confidence) < math.SmallestNonzeroFloat64 {
+		if m[i].Name == m[j].Name {
+			if m[i].Offset > m[j].Offset {
+				return false
+			}
+			if m[i].Offset == m[j].Offset {
+				return m[i].Extent > m[j].Extent
+			}
+			return true
+		}
+		return m[i].Name < m[j].Name
+	}
+	return m[i].Confidence > m[j].Confidence
+}
+
+// Names returns an unsorted slice of the names of the matched licenses.
+func (m Matches) Names() []string {
+	var names []string
+	for _, n := range m {
+		names = append(names, n.Name)
+	}
+	return names
+}
+
+// uniquify goes through the matches and removes any that are contained within
+// one with a higher confidence. This assumes that Matches is sorted.
+func (m Matches) uniquify() Matches {
+	type matchedRange struct {
+		offset, extent int
+	}
+
+	var matched []matchedRange
+	var matches Matches
+OUTER:
+	for _, match := range m {
+		for _, mr := range matched {
+			if match.Offset >= mr.offset && match.Offset <= mr.offset+mr.extent {
+				continue OUTER
+			}
+		}
+		matched = append(matched, matchedRange{match.Offset, match.Extent})
+		matches = append(matches, match)
+	}
+
+	return matches
+}
+
+// NearestMatch returns the name of the known value that most closely matches
+// the unknown string and a confidence percentage is returned indicating how
+// confident the classifier is in the result. A percentage of "1.0" indicates
+// an exact match, while a percentage of "0.0" indicates a complete mismatch.
+//
+// If the string is equidistant from multiple known values, it is undefined
+// which will be returned.
+func (c *Classifier) NearestMatch(s string) *Match {
+	pq := c.nearestMatch(s)
+	if pq.Len() == 0 {
+		return &Match{}
+	}
+	return pq.Pop().(*Match)
+}
+
+// MultipleMatch tries to determine which known strings are found within an
+// unknown string. This differs from "NearestMatch" in that it looks only at
+// those areas within the unknown string that are likely to match. A list of
+// potential matches are returned. It's up to the caller to determine which
+// ones are acceptable.
+func (c *Classifier) MultipleMatch(s string) (matches Matches) {
+	pq := c.multipleMatch(s)
+	if pq == nil {
+		return matches
+	}
+
+	// A map to remove duplicate entries.
+	m := make(map[Match]bool)
+
+	for pq.Len() != 0 {
+		v := pq.Pop().(*Match)
+		if _, ok := m[*v]; !ok {
+			m[*v] = true
+			matches = append(matches, v)
+		}
+	}
+
+	sort.Sort(matches)
+	return matches.uniquify()
+}
+
+// possibleMatch identifies a known value and it's diffRatio to a given string.
+type possibleMatch struct {
+	value     *knownValue
+	diffRatio float64
+}
+
+// likelyMatches is a slice of possibleMatches that can be sorted by their
+// diffRatio to a given string, such that the most likely matches (based on
+// length) are at the beginning.
+type likelyMatches []possibleMatch
+
+func (m likelyMatches) Len() int           { return len(m) }
+func (m likelyMatches) Less(i, j int) bool { return m[i].diffRatio > m[j].diffRatio }
+func (m likelyMatches) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+// nearestMatch returns a Queue of values that the unknown string may be. The
+// values are compared via their Levenshtein Distance and ranked with the
+// nearest match at the beginning.
+func (c *Classifier) nearestMatch(unknown string) *pq.Queue {
+	var mu sync.Mutex // Protect the priority queue.
+	pq := pq.NewQueue(func(x, y interface{}) bool {
+		return x.(*Match).Confidence > y.(*Match).Confidence
+	}, nil)
+
+	unknown = c.normalize(unknown)
+	if len(unknown) == 0 {
+		return pq
+	}
+
+	c.muValues.RLock()
+	var likely likelyMatches
+	for _, v := range c.values {
+		dr := diffRatio(unknown, v.normalizedValue)
+		if dr < c.MinDiffRatio {
+			continue
+		}
+		if unknown == v.normalizedValue {
+			// We found an exact match.
+			pq.Push(&Match{Name: v.key, Confidence: 1.0, Offset: 0, Extent: len(unknown)})
+			c.muValues.RUnlock()
+			return pq
+		}
+		likely = append(likely, possibleMatch{value: v, diffRatio: dr})
+	}
+	c.muValues.RUnlock()
+	sort.Sort(likely)
+
+	var wg sync.WaitGroup
+	classifyString := func(name, unknown, known string) {
+		defer wg.Done()
+
+		diffs := dmp.DiffMain(unknown, known, true)
+		distance := dmp.DiffLevenshtein(diffs)
+		confidence := confidencePercentage(len(unknown), len(known), distance)
+		if confidence > 0.0 {
+			mu.Lock()
+			pq.Push(&Match{Name: name, Confidence: confidence, Offset: 0, Extent: len(unknown)})
+			mu.Unlock()
+		}
+	}
+
+	wg.Add(len(likely))
+	for _, known := range likely {
+		go classifyString(known.value.key, unknown, known.value.normalizedValue)
+	}
+	wg.Wait()
+	return pq
+}
+
+// matcher finds all potential matches of "known" in "unknown". The results are
+// placed in "queue".
+type matcher struct {
+	unknown     *searchset.SearchSet
+	normUnknown string
+	threshold   float64
+
+	mu    sync.Mutex
+	queue *pq.Queue
+}
+
+// newMatcher creates a "matcher" object.
+func newMatcher(unknown string, threshold float64) *matcher {
+	return &matcher{
+		unknown:     searchset.New(unknown, searchset.DefaultGranularity),
+		normUnknown: unknown,
+		threshold:   threshold,
+		queue: pq.NewQueue(func(x, y interface{}) bool {
+			return x.(*Match).Confidence > y.(*Match).Confidence
+		}, nil),
+	}
+}
+
+// findMatches takes a known text and finds all potential instances of it in
+// the unknown text. The resulting matches can then filtered to determine which
+// are the best matches.
+func (m *matcher) findMatches(known *knownValue) {
+	var mrs []searchset.MatchRanges
+	if all := known.reValue.FindAllStringIndex(m.normUnknown, -1); all != nil {
+		// We found exact matches. Just use those!
+		for _, a := range all {
+			var start, end int
+			for i, tok := range m.unknown.Tokens {
+				if tok.Offset == a[0] {
+					start = i
+				} else if tok.Offset >= a[len(a)-1]-len(tok.Text) {
+					end = i
+					break
+				}
+			}
+
+			mrs = append(mrs, searchset.MatchRanges{{
+				SrcStart:    0,
+				SrcEnd:      len(known.set.Tokens),
+				TargetStart: start,
+				TargetEnd:   end + 1,
+			}})
+		}
+	} else {
+		// No exact match. Perform a more thorough match.
+		mrs = searchset.FindPotentialMatches(known.set, m.unknown)
+	}
+
+	var wg sync.WaitGroup
+	for _, mr := range mrs {
+		if !m.withinConfidenceThreshold(known.set, mr) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(mr searchset.MatchRanges) {
+			start, end := mr.TargetRange(m.unknown)
+			conf := levDist(m.normUnknown[start:end], known.normalizedValue)
+			if conf > 0.0 {
+				m.mu.Lock()
+				m.queue.Push(&Match{Name: known.key, Confidence: conf, Offset: start, Extent: end - start})
+				m.mu.Unlock()
+			}
+			wg.Done()
+		}(mr)
+	}
+	wg.Wait()
+}
+
+// withinConfidenceThreshold returns the Confidence we have in the potential
+// match. It does this by calculating the ratio of what's matching to the
+// original known text.
+func (m *matcher) withinConfidenceThreshold(known *searchset.SearchSet, mr searchset.MatchRanges) bool {
+	return float64(mr.Size())/float64(len(known.Tokens)) >= m.threshold
+}
+
+// multipleMatch returns a Queue of values that might be within the unknown
+// string. The values are compared via their Levenshtein Distance and ranked
+// with the nearest match at the beginning.
+func (c *Classifier) multipleMatch(unknown string) *pq.Queue {
+	normUnknown := c.normalize(unknown)
+	if normUnknown == "" {
+		return nil
+	}
+
+	m := newMatcher(normUnknown, c.threshold)
+
+	c.muValues.RLock()
+	var kvals []*knownValue
+	for _, known := range c.values {
+		kvals = append(kvals, known)
+	}
+	c.muValues.RUnlock()
+
+	var wg sync.WaitGroup
+	wg.Add(len(kvals))
+	for _, known := range kvals {
+		go func(known *knownValue) {
+			if known.set == nil {
+				k := searchset.New(known.normalizedValue, searchset.DefaultGranularity)
+				c.muValues.Lock()
+				c.values[known.key].set = k
+				c.muValues.Unlock()
+			}
+			m.findMatches(known)
+			wg.Done()
+		}(known)
+	}
+	wg.Wait()
+	return m.queue
+}
+
+// levDist runs the Levenshtein Distance algorithm on the known and unknown
+// texts to measure how well they match.
+func levDist(unknown, known string) float64 {
+	if len(known) == 0 || len(unknown) == 0 {
+		log.Printf("Zero-sized texts in Levenshtein Distance algorithm: known==%d, unknown==%d", len(known), len(unknown))
+		return 0.0
+	}
+
+	// Calculate the differences between the potentially matching known
+	// text and the unknown text.
+	diffs := dmp.DiffMain(unknown, known, false)
+	end := diffRangeEnd(known, diffs)
+
+	// Now execute the Levenshtein Distance algorithm to see how much it
+	// does match.
+	distance := dmp.DiffLevenshtein(diffs[:end])
+	return confidencePercentage(unknownTextLength(unknown, diffs), len(known), distance)
+}
+
+// unknownTextLength returns the length of the unknown text based on the diff range.
+func unknownTextLength(unknown string, diffs []diffmatchpatch.Diff) int {
+	last := len(diffs) - 1
+	for ; last >= 0; last-- {
+		if diffs[last].Type == diffmatchpatch.DiffEqual {
+			break
+		}
+	}
+	ulen := 0
+	for i := 0; i < last+1; i++ {
+		switch diffs[i].Type {
+		case diffmatchpatch.DiffEqual, diffmatchpatch.DiffDelete:
+			ulen += len(diffs[i].Text)
+		}
+	}
+	return ulen
+}
+
+// diffRangeEnd returns the end index for the "Diff" objects that constructs
+// (or nearly constructs) the "known" value.
+func diffRangeEnd(known string, diffs []diffmatchpatch.Diff) (end int) {
+	var seen string
+	for end = 0; end < len(diffs); end++ {
+		if seen == known {
+			// Once we've constructed the "known" value, then we've
+			// reached the point in the diff list where more
+			// "Diff"s would just make the Levenshtein Distance
+			// less valid. There shouldn't be further "DiffEqual"
+			// nodes, because there's nothing further to match in
+			// the "known" text.
+			break
+		}
+		switch diffs[end].Type {
+		case diffmatchpatch.DiffEqual, diffmatchpatch.DiffInsert:
+			seen += diffs[end].Text
+		}
+	}
+	return end
+}
+
+// confidencePercentage calculates how confident we are in the result of the
+// match. A percentage of "1.0" means an identical match. A confidence of "0.0"
+// means a complete mismatch.
+func confidencePercentage(ulen, klen, distance int) float64 {
+	if ulen == 0 && klen == 0 {
+		return 1.0
+	}
+	if ulen == 0 || klen == 0 || (distance > ulen && distance > klen) {
+		return 0.0
+	}
+	return 1.0 - float64(distance)/float64(max(ulen, klen))
+}
+
+// diffRatio calculates the ratio of the length of s1 and s2, returned as a
+// percentage of the length of the longer string. E.g., diffLength("abcd", "e")
+// would return 0.25 because "e" is 25% of the size of "abcd". Comparing
+// strings of equal length will return 1.
+func diffRatio(s1, s2 string) float64 {
+	x, y := len(s1), len(s2)
+	if x == 0 && y == 0 {
+		// Both strings are zero length
+		return 1.0
+	}
+	if x < y {
+		return float64(x) / float64(y)
+	}
+	return float64(y) / float64(x)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// wsRegexp is a regexp used to identify blocks of whitespace.
+var wsRegexp = regexp.MustCompile(`\s+`)
+
+// FlattenWhitespace will flatten contiguous blocks of whitespace down to a single space.
+var FlattenWhitespace NormalizeFunc = func(s string) string {
+	return wsRegexp.ReplaceAllString(s, " ")
+}

--- a/vendor/github.com/google/licenseclassifier/stringclassifier/internal/pq/priority.go
+++ b/vendor/github.com/google/licenseclassifier/stringclassifier/internal/pq/priority.go
@@ -1,0 +1,111 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pq provides a priority queue.
+package pq
+
+import "container/heap"
+
+// NewQueue returns an unbounded priority queue that compares elements using
+// less; the minimal element is at the top of the queue.
+//
+// If setIndex is not nil, the queue calls setIndex to inform each element of
+// its position in the queue.  If an element's priority changes, its position in
+// the queue may be incorrect.  Call Fix on the element's index to update the
+// queue.  Call Remove on the element's index to remove it from the queue.
+func NewQueue(less func(x, y interface{}) bool, setIndex func(x interface{}, idx int)) *Queue {
+	return &Queue{
+		heap: pqHeap{
+			less:     less,
+			setIndex: setIndex,
+		},
+	}
+}
+
+// Queue is a priority queue that supports updating the priority of an element.
+// A Queue must be created with NewQueue.
+type Queue struct {
+	heap pqHeap
+}
+
+// Len returns the number of elements in the queue.
+func (pq *Queue) Len() int {
+	return pq.heap.Len()
+}
+
+// Push adds x to the queue.
+func (pq *Queue) Push(x interface{}) {
+	heap.Push(&pq.heap, x)
+}
+
+// Min returns the minimal element.
+// Min panics if the queue is empty.
+func (pq *Queue) Min() interface{} {
+	return pq.heap.a[0]
+}
+
+// Pop removes and returns the minimal element.
+// Pop panics if the queue is empty.
+func (pq *Queue) Pop() interface{} {
+	return heap.Pop(&pq.heap)
+}
+
+// Fix adjusts the heap to reflect that the element at index has changed priority.
+func (pq *Queue) Fix(index int) {
+	heap.Fix(&pq.heap, index)
+}
+
+// Remove removes the element at index i from the heap.
+func (pq *Queue) Remove(index int) {
+	heap.Remove(&pq.heap, index)
+}
+
+// pqHeap implements heap.Interface.
+type pqHeap struct {
+	a        []interface{}
+	less     func(x, y interface{}) bool
+	setIndex func(x interface{}, idx int)
+}
+
+func (h pqHeap) Len() int {
+	return len(h.a)
+}
+
+func (h pqHeap) Less(i, j int) bool {
+	return h.less(h.a[i], h.a[j])
+}
+
+func (h pqHeap) Swap(i, j int) {
+	h.a[i], h.a[j] = h.a[j], h.a[i]
+	if h.setIndex != nil {
+		h.setIndex(h.a[i], i)
+		h.setIndex(h.a[j], j)
+	}
+}
+
+func (h *pqHeap) Push(x interface{}) {
+	n := len(h.a)
+	if h.setIndex != nil {
+		h.setIndex(x, n)
+	}
+	h.a = append(h.a, x)
+}
+
+func (h *pqHeap) Pop() interface{} {
+	old := h.a
+	n := len(old)
+	x := old[n-1]
+	h.a = old[:n-1]
+	return x
+}

--- a/vendor/github.com/google/licenseclassifier/stringclassifier/searchset/searchset.go
+++ b/vendor/github.com/google/licenseclassifier/stringclassifier/searchset/searchset.go
@@ -1,0 +1,491 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package searchset generates hashes for all substrings of a text. Potential
+// matches between two SearchSet objects can then be determined quickly.
+// Generating the hashes can be expensive, so it's best to perform it once. If
+// the text is part of a known corpus, then the SearchSet can be serialized and
+// kept in an archive.
+//
+// Matching occurs by "mapping" ranges from the source text into the target
+// text but still retaining the source order:
+//
+//   SOURCE: |-----------------------------|
+//
+//   TARGET: |*****************************************|
+//
+//   MAP SOURCE SECTIONS ONTO TARGET IN SOURCE ORDER:
+//
+//     S:  |-[--]-----[---]------[----]------|
+//            /         |           \
+//         |---|   |---------|   |-------------|
+//     T: |*****************************************|
+//
+// Note that a single source range may match many different ranges in the
+// target. The matching algorithm untangles these so that all matched ranges
+// are in order with respect to the source ranges. This is especially important
+// since the source text may occur more than once in the target text. The
+// algorithm finds each potential occurrence of S in T and returns all as
+// potential matched ranges.
+package searchset
+
+import (
+	"encoding/gob"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/google/licenseclassifier/stringclassifier/searchset/tokenizer"
+)
+
+// DefaultGranularity is the minimum size (in words) of the hash chunks.
+const DefaultGranularity = 3
+
+// SearchSet is a set of substrings that have hashes associated with them,
+// making it fast to search for potential matches.
+type SearchSet struct {
+	// Tokens is a tokenized list of the original input string.
+	Tokens tokenizer.Tokens
+	// Hashes is a map of checksums to a range of tokens.
+	Hashes tokenizer.Hash
+	// Checksums is a list of checksums ordered from longest range to
+	// shortest.
+	Checksums []uint32
+	// ChecksumRanges are the token ranges for the above checksums.
+	ChecksumRanges tokenizer.TokenRanges
+
+	nodes []*node
+}
+
+// node consists of a range of tokens along with the checksum for those tokens.
+type node struct {
+	checksum uint32
+	tokens   *tokenizer.TokenRange
+}
+
+func (n *node) String() string {
+	return fmt.Sprintf("[%d:%d]", n.tokens.Start, n.tokens.End)
+}
+
+// New creates a new SearchSet object. It generates a hash for each substring of "s".
+func New(s string, granularity int) *SearchSet {
+	toks := tokenizer.Tokenize(s)
+
+	// Start generating hash values for all substrings within the text.
+	h := make(tokenizer.Hash)
+	checksums, tokenRanges := toks.GenerateHashes(h, func(a, b int) int {
+		if a < b {
+			return a
+		}
+		return b
+	}(len(toks), granularity))
+	sset := &SearchSet{
+		Tokens:         toks,
+		Hashes:         h,
+		Checksums:      checksums,
+		ChecksumRanges: tokenRanges,
+	}
+	sset.GenerateNodeList()
+	return sset
+}
+
+// GenerateNodeList creates a node list out of the search set.
+func (s *SearchSet) GenerateNodeList() {
+	if len(s.Tokens) == 0 {
+		return
+	}
+
+	for i := 0; i < len(s.Checksums); i++ {
+		s.nodes = append(s.nodes, &node{
+			checksum: s.Checksums[i],
+			tokens:   s.ChecksumRanges[i],
+		})
+	}
+}
+
+// Serialize emits the SearchSet out so that it can be recreated at a later
+// time.
+func (s *SearchSet) Serialize(w io.Writer) error {
+	return gob.NewEncoder(w).Encode(s)
+}
+
+// Deserialize reads a file with a serialized SearchSet in it and reconstructs it.
+func Deserialize(r io.Reader, s *SearchSet) error {
+	if err := gob.NewDecoder(r).Decode(&s); err != nil {
+		return err
+	}
+	s.GenerateNodeList()
+	return nil
+}
+
+// MatchRange is the range within the source text that is a match to the range
+// in the target text.
+type MatchRange struct {
+	// Offsets into the source tokens.
+	SrcStart, SrcEnd int
+	// Offsets into the target tokens.
+	TargetStart, TargetEnd int
+}
+
+// in returns true if the start and end are enclosed in the match range.
+func (m *MatchRange) in(start, end int) bool {
+	return start >= m.TargetStart && end <= m.TargetEnd
+}
+
+func (m *MatchRange) String() string {
+	return fmt.Sprintf("[%v, %v)->[%v, %v)", m.SrcStart, m.SrcEnd, m.TargetStart, m.TargetEnd)
+}
+
+// MatchRanges is a list of "MatchRange"s. The ranges are monotonically
+// increasing in value and indicate a single potential occurrence of the source
+// text in the target text.
+type MatchRanges []*MatchRange
+
+func (m MatchRanges) Len() int      { return len(m) }
+func (m MatchRanges) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
+func (m MatchRanges) Less(i, j int) bool {
+	if m[i].TargetStart < m[j].TargetStart {
+		return true
+	}
+	return m[i].TargetStart == m[j].TargetStart && m[i].SrcStart < m[j].SrcStart
+}
+
+// TargetRange is the start and stop token offsets into the target text.
+func (m MatchRanges) TargetRange(target *SearchSet) (start, end int) {
+	start = target.Tokens[m[0].TargetStart].Offset
+	end = target.Tokens[m[len(m)-1].TargetEnd-1].Offset + len(target.Tokens[m[len(m)-1].TargetEnd-1].Text)
+	return start, end
+}
+
+// Size is the number of source tokens that were matched.
+func (m MatchRanges) Size() int {
+	sum := 0
+	for _, mr := range m {
+		sum += mr.SrcEnd - mr.SrcStart
+	}
+	return sum
+}
+
+// FindPotentialMatches returns the ranges in the target (unknown) text that
+// are best potential matches to the source (known) text.
+func FindPotentialMatches(src, target *SearchSet) []MatchRanges {
+	matchedRanges := getMatchedRanges(src, target)
+	if len(matchedRanges) == 0 {
+		return nil
+	}
+
+	// Cleanup the matching ranges so that we get the longest contiguous ranges.
+	for i := 0; i < len(matchedRanges); i++ {
+		matchedRanges[i] = coalesceMatchRanges(matchedRanges[i])
+	}
+	return matchedRanges
+}
+
+// getMatchedRanges finds the ranges in the target text that match the source
+// text. There can be multiple occurrences of the source text within the target
+// text. Each separate occurrence is an entry in the returned slice.
+func getMatchedRanges(src, target *SearchSet) []MatchRanges {
+	matched := targetMatchedRanges(src, target)
+	if len(matched) == 0 {
+		return nil
+	}
+	sort.Sort(matched)
+	matched = untangleSourceRanges(matched)
+	matchedRanges := splitRanges(matched)
+	return mergeConsecutiveRanges(matchedRanges)
+}
+
+func extendsAny(tr tokenizer.TokenRanges, mr []MatchRanges) bool {
+	if len(mr) == 0 {
+		return false
+	}
+	for _, tv := range tr {
+		for _, mv := range mr {
+			if tv.Start >= mv[0].TargetStart && tv.Start <= mv[len(mv)-1].TargetEnd {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// targetMatchedRanges finds matching sequences in target and src ordered by target position
+func targetMatchedRanges(src, target *SearchSet) MatchRanges {
+	if src.nodes == nil {
+		return nil
+	}
+
+	var matched MatchRanges
+	var previous *node
+	var possible []MatchRanges
+	for _, tgtNode := range target.nodes {
+		sr, ok := src.Hashes[tgtNode.checksum]
+		if !ok || (previous != nil && tgtNode.tokens.Start > previous.tokens.End) || !extendsAny(sr, possible) {
+			for _, r := range possible {
+				matched = append(matched, r...)
+			}
+			possible = possible[:0]
+			previous = nil
+		}
+		if !ok {
+			// There isn't a match in the source.
+			continue
+		}
+
+		// Maps index within `possible` to the slice of ranges extended by a new range
+		extended := make(map[int]*MatchRanges)
+		// Go over the set of source ranges growing lists of `possible` match ranges.
+		tv := tgtNode.tokens
+		for _, sv := range sr {
+			r := &MatchRange{
+				SrcStart:    sv.Start,
+				SrcEnd:      sv.End,
+				TargetStart: tv.Start,
+				TargetEnd:   tv.End,
+			}
+			found := false
+			// Grow or extend each abutting `possible` match range.
+			for i, p := range possible {
+				last := p[len(p)-1]
+				if sv.Start >= last.SrcStart && sv.Start <= last.SrcEnd && tv.Start >= last.TargetStart && tv.Start <= last.TargetEnd {
+					found = true
+					possible[i] = append(possible[i], r)
+					extended[i] = &possible[i]
+				}
+			}
+			if !found {
+				// Did not abut any existing ranges, start a new `possible` match range.
+				mrs := make(MatchRanges, 0, 2)
+				mrs = append(mrs, r)
+				possible = append(possible, mrs)
+				extended[len(possible)-1] = &possible[len(possible)-1]
+			}
+		}
+		if len(extended) < len(possible) {
+			// Ranges not extended--add to `matched` if not included in other range.
+			for i := 0; i < len(possible); {
+				_, updated := extended[i]
+				if updated {
+					i++ // Keep in `possible` and advance to next index.
+					continue
+				}
+				p1 := possible[i]
+				found := false // whether found as subrange of another `possible` match.
+				for _, p2 := range extended {
+					if p1[0].SrcStart >= (*p2)[0].SrcStart && p1[0].TargetStart >= (*p2)[0].TargetStart {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matched = append(matched, p1...)
+				} // else included in other match.
+				// Finished -- delete from `possible` and continue from same index.
+				possible = append(possible[:i], possible[i+1:]...)
+			}
+		}
+		previous = tgtNode
+	}
+	// At end of file, terminate all `possible` match ranges.
+	for i := 0; i < len(possible); i++ {
+		p1 := possible[i]
+		found := false // whether found as subrange of another `possible` match.
+		for j := i + 1; j < len(possible); {
+			p2 := possible[j]
+			if p1[0].SrcStart <= p2[0].SrcStart && p1[0].TargetStart <= p2[0].TargetStart {
+				// Delete later sub-ranges included in this range.
+				possible = append(possible[:j], possible[j+1:]...)
+				continue
+			}
+			// Skip if subrange of a later range
+			if p1[0].SrcStart >= p2[0].SrcStart && p1[0].TargetStart >= p2[0].TargetStart {
+				found = true
+			}
+			j++
+		}
+		if !found {
+			matched = append(matched, p1...)
+		}
+	}
+	return matched
+}
+
+// untangleSourceRanges goes through the ranges and removes any whose source
+// ranges are "out of order". A source range is "out of order" if the source
+// range is out of sequence with the source ranges before and after it. This
+// happens when more than one source range maps to the same target range.
+// E.g.:
+//
+//     SrcStart: 20, SrcEnd: 30, TargetStart: 127, TargetEnd: 137
+//  1: SrcStart: 12, SrcEnd: 17, TargetStart: 138, TargetEnd: 143
+//  2: SrcStart: 32, SrcEnd: 37, TargetStart: 138, TargetEnd: 143
+//     SrcStart: 38, SrcEnd: 40, TargetStart: 144, TargetEnd: 146
+//
+// Here (1) is out of order, because the source range [12, 17) is out of
+// sequence with the surrounding source sequences, but [32, 37) is.
+func untangleSourceRanges(matched MatchRanges) MatchRanges {
+	mr := MatchRanges{matched[0]}
+NEXT:
+	for i := 1; i < len(matched); i++ {
+		if mr[len(mr)-1].TargetStart == matched[i].TargetStart && mr[len(mr)-1].TargetEnd == matched[i].TargetEnd {
+			// The matched range has already been added.
+			continue
+		}
+
+		if i+1 < len(matched) && equalTargetRange(matched[i], matched[i+1]) {
+			// A sequence of ranges match the same target range.
+			// Find the first one that has a source range greater
+			// than the currently matched range. Omit all others.
+			if matched[i].SrcStart > mr[len(mr)-1].SrcStart {
+				mr = append(mr, matched[i])
+				continue
+			}
+
+			for j := i + 1; j < len(matched) && equalTargetRange(matched[i], matched[j]); j++ {
+				// Check subsequent ranges to see if we can
+				// find one that matches in the correct order.
+				if matched[j].SrcStart > mr[len(mr)-1].SrcStart {
+					mr = append(mr, matched[j])
+					i = j
+					continue NEXT
+				}
+			}
+		}
+
+		mr = append(mr, matched[i])
+	}
+	return mr
+}
+
+// equalTargetRange returns true if the two MatchRange's cover the same target range.
+func equalTargetRange(this, that *MatchRange) bool {
+	return this.TargetStart == that.TargetStart && this.TargetEnd == that.TargetEnd
+}
+
+// splitRanges splits the matched ranges so that a single match range has a
+// monotonically increasing source range (indicating a single, potential
+// instance of the source in the target).
+func splitRanges(matched MatchRanges) []MatchRanges {
+	var matchedRanges []MatchRanges
+	mr := MatchRanges{matched[0]}
+	for i := 1; i < len(matched); i++ {
+		if mr[len(mr)-1].SrcStart > matched[i].SrcStart {
+			matchedRanges = append(matchedRanges, mr)
+			mr = MatchRanges{matched[i]}
+		} else {
+			mr = append(mr, matched[i])
+		}
+	}
+	matchedRanges = append(matchedRanges, mr)
+	return matchedRanges
+}
+
+// mergeConsecutiveRanges goes through the matched ranges and merges
+// consecutive ranges. Two ranges are consecutive if the end of the previous
+// matched range and beginning of the next matched range overlap. "matched"
+// should have 1 or more MatchRanges, each with one or more MatchRange objects.
+func mergeConsecutiveRanges(matched []MatchRanges) []MatchRanges {
+	mr := []MatchRanges{matched[0]}
+
+	// Convenience functions.
+	prevMatchedRange := func() MatchRanges {
+		return mr[len(mr)-1]
+	}
+	prevMatchedRangeLastElem := func() *MatchRange {
+		return prevMatchedRange()[len(prevMatchedRange())-1]
+	}
+
+	// This algorithm compares the start of each MatchRanges object to the
+	// end of the previous MatchRanges object. If they overlap, then it
+	// tries to combine them. Note that a 0 offset into a MatchRanges
+	// object (e.g., matched[i][0]) is its first MatchRange, which
+	// indicates the start of the whole matched range.
+NEXT:
+	for i := 1; i < len(matched); i++ {
+		if prevMatchedRangeLastElem().TargetEnd > matched[i][0].TargetStart {
+			// Consecutive matched ranges overlap. Merge them.
+			if prevMatchedRangeLastElem().TargetStart < matched[i][0].TargetStart {
+				// The last element of the previous matched
+				// range overlaps with the first element of the
+				// current matched range. Concatenate them.
+				if prevMatchedRangeLastElem().TargetEnd < matched[i][0].TargetEnd {
+					prevMatchedRangeLastElem().SrcEnd += matched[i][0].TargetEnd - prevMatchedRangeLastElem().TargetEnd
+					prevMatchedRangeLastElem().TargetEnd = matched[i][0].TargetEnd
+				}
+				mr[len(mr)-1] = append(prevMatchedRange(), matched[i][1:]...)
+				continue
+			}
+
+			for j := 1; j < len(matched[i]); j++ {
+				// Find the positions in the ranges where the
+				// tail end of the previous matched range
+				// overlaps with the start of the next matched
+				// range.
+				for k := len(prevMatchedRange()) - 1; k > 0; k-- {
+					if prevMatchedRange()[k].SrcStart < matched[i][j].SrcStart &&
+						prevMatchedRange()[k].TargetStart < matched[i][j].TargetStart {
+						// Append the next range to the previous range.
+						if prevMatchedRange()[k].TargetEnd < matched[i][j].TargetStart {
+							// Coalesce the ranges.
+							prevMatchedRange()[k].SrcEnd += matched[i][j-1].TargetEnd - prevMatchedRange()[k].TargetEnd
+							prevMatchedRange()[k].TargetEnd = matched[i][j-1].TargetEnd
+						}
+						mr[len(mr)-1] = append(prevMatchedRange()[:k+1], matched[i][j:]...)
+						continue NEXT
+					}
+				}
+			}
+		}
+		mr = append(mr, matched[i])
+	}
+	return mr
+}
+
+// coalesceMatchRanges coalesces overlapping match ranges into a single
+// contiguous match range.
+func coalesceMatchRanges(matchedRanges MatchRanges) MatchRanges {
+	coalesced := MatchRanges{matchedRanges[0]}
+	for i := 1; i < len(matchedRanges); i++ {
+		c := coalesced[len(coalesced)-1]
+		mr := matchedRanges[i]
+
+		if mr.SrcStart <= c.SrcEnd && mr.SrcStart >= c.SrcStart {
+			var se, ts, te int
+			if mr.SrcEnd > c.SrcEnd {
+				se = mr.SrcEnd
+			} else {
+				se = c.SrcEnd
+			}
+			if mr.TargetStart < c.TargetStart {
+				ts = mr.TargetStart
+			} else {
+				ts = c.TargetStart
+			}
+			if mr.TargetEnd > c.TargetEnd {
+				te = mr.TargetEnd
+			} else {
+				te = c.TargetEnd
+			}
+			coalesced[len(coalesced)-1] = &MatchRange{
+				SrcStart:    c.SrcStart,
+				SrcEnd:      se,
+				TargetStart: ts,
+				TargetEnd:   te,
+			}
+		} else {
+			coalesced = append(coalesced, mr)
+		}
+	}
+	return coalesced
+}

--- a/vendor/github.com/google/licenseclassifier/stringclassifier/searchset/tokenizer/tokenizer.go
+++ b/vendor/github.com/google/licenseclassifier/stringclassifier/searchset/tokenizer/tokenizer.go
@@ -1,0 +1,175 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tokenizer converts a text into a stream of tokens.
+package tokenizer
+
+import (
+	"bytes"
+	"fmt"
+	"hash/crc32"
+	"sort"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Token is a non-whitespace sequence (i.e., word or punctuation) in the
+// original string. This is not meant for use outside of this package.
+type token struct {
+	Text   string
+	Offset int
+}
+
+// Tokens is a list of Token objects.
+type Tokens []*token
+
+// newToken creates a new token object with an invalid (negative) offset, which
+// will be set before the token's used.
+func newToken() *token {
+	return &token{Offset: -1}
+}
+
+// Tokenize converts a string into a stream of tokens.
+func Tokenize(s string) (toks Tokens) {
+	tok := newToken()
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		switch {
+		case unicode.IsSpace(r):
+			if tok.Offset >= 0 {
+				toks = append(toks, tok)
+				tok = newToken()
+			}
+		case unicode.IsPunct(r):
+			if tok.Offset >= 0 {
+				toks = append(toks, tok)
+				tok = newToken()
+			}
+			toks = append(toks, &token{
+				Text:   string(r),
+				Offset: i,
+			})
+		default:
+			if tok.Offset == -1 {
+				tok.Offset = i
+			}
+			tok.Text += string(r)
+		}
+		i += size
+	}
+	if tok.Offset != -1 {
+		// Add any remaining token that wasn't yet included in the list.
+		toks = append(toks, tok)
+	}
+	return toks
+}
+
+// GenerateHashes generates hashes for "size" length substrings. The
+// "stringifyTokens" call takes a long time to run, so not all substrings have
+// hashes, i.e. we skip some of the smaller substrings.
+func (t Tokens) GenerateHashes(h Hash, size int) ([]uint32, TokenRanges) {
+	if size == 0 {
+		return nil, nil
+	}
+
+	var css []uint32
+	var tr TokenRanges
+	for offset := 0; offset+size <= len(t); offset += size / 2 {
+		var b bytes.Buffer
+		t.stringifyTokens(&b, offset, size)
+		cs := crc32.ChecksumIEEE(b.Bytes())
+		css = append(css, cs)
+		tr = append(tr, &TokenRange{offset, offset + size})
+		h.add(cs, offset, offset+size)
+		if size <= 1 {
+			break
+		}
+	}
+
+	return css, tr
+}
+
+// stringifyTokens serializes a sublist of tokens into a bytes buffer.
+func (t Tokens) stringifyTokens(b *bytes.Buffer, offset, size int) {
+	for j := offset; j < offset+size; j++ {
+		if j != offset {
+			b.WriteRune(' ')
+		}
+		b.WriteString(t[j].Text)
+	}
+}
+
+// TokenRange indicates the range of tokens that map to a particular checksum.
+type TokenRange struct {
+	Start int
+	End   int
+}
+
+func (t *TokenRange) String() string {
+	return fmt.Sprintf("[%v, %v)", t.Start, t.End)
+}
+
+// TokenRanges is a list of TokenRange objects. The chance that two different
+// strings map to the same checksum is very small, but unfortunately isn't
+// zero, so we use this instead of making the assumption that they will all be
+// unique.
+type TokenRanges []*TokenRange
+
+func (t TokenRanges) Len() int           { return len(t) }
+func (t TokenRanges) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+func (t TokenRanges) Less(i, j int) bool { return t[i].Start < t[j].Start }
+
+// CombineUnique returns the combination of both token ranges with no duplicates.
+func (t TokenRanges) CombineUnique(other TokenRanges) TokenRanges {
+	if len(other) == 0 {
+		return t
+	}
+	if len(t) == 0 {
+		return other
+	}
+
+	cu := append(t, other...)
+	sort.Sort(cu)
+
+	if len(cu) == 0 {
+		return nil
+	}
+
+	res := TokenRanges{cu[0]}
+	for prev, i := cu[0], 1; i < len(cu); i++ {
+		if prev.Start != cu[i].Start || prev.End != cu[i].End {
+			res = append(res, cu[i])
+			prev = cu[i]
+		}
+	}
+	return res
+}
+
+// Hash is a map of the hashes of a section of text to the token range covering that text.
+type Hash map[uint32]TokenRanges
+
+// add associates a token range, [start, end], to a checksum.
+func (h Hash) add(checksum uint32, start, end int) {
+	ntr := &TokenRange{Start: start, End: end}
+	if r, ok := h[checksum]; ok {
+		for _, tr := range r {
+			if tr.Start == ntr.Start && tr.End == ntr.End {
+				// The token range already exists at this
+				// checksum. No need to re-add it.
+				return
+			}
+		}
+	}
+	h[checksum] = append(h[checksum], ntr)
+}

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/README.md
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/README.md
@@ -1,0 +1,88 @@
+# dep-collector
+
+`dep-collector` is a tool for gathering up a collection of licenses for Go
+dependencies that have been pulled into the idiomatic `vendor/` directory.
+The resulting file from running `dep-collector` is intended for inclusion
+in container images to respect the licenses of the included software.
+
+### Basic Usage
+
+You can run `dep-collector` on one or more Go import paths as entrypoints,
+and it will:
+1. Walk the transitive dependencies to identify vendored software packages,
+1. Search for licenses for each vendored dependency,
+1. Dump a file containing the licenses for each vendored import.
+
+For example (single import path):
+```shell
+$ dep-collector .
+===========================================================
+Import: github.com/mattmoor/dep-collector/vendor/github.com/google/licenseclassifier
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+...
+
+```
+
+For example (multiple import paths):
+
+```shell
+$ dep-collector ./cmd/controller ./cmd/sleeper
+
+===========================================================
+Import: github.com/mattmoor/warm-image/vendor/cloud.google.com/go
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+```
+
+### CSV Usage
+
+You can also run `dep-collector` in a mode that produces CSV output,
+including basic classification of the license.
+
+> In order to run dep-collector in this mode, you must first run:
+>   go get github.com/google/licenseclassifier
+
+For example:
+
+```shell
+$ dep-collector -csv .
+github.com/google/licenseclassifier,Static,,https://github.com/mattmoor/dep-collector/blob/master/vendor/github.com/google/licenseclassifier/LICENSE,Apache-2.0
+github.com/google/licenseclassifier/stringclassifier,Static,,https://github.com/mattmoor/dep-collector/blob/master/vendor/github.com/google/licenseclassifier/stringclassifier/LICENSE,Apache-2.0
+github.com/sergi/go-diff,Static,,https://github.com/mattmoor/dep-collector/blob/master/vendor/github.com/sergi/go-diff/LICENSE,MIT
+
+```
+
+The columns here are:
+* Import Path,
+* How the dependency is linked in (always reports "static"),
+* A column for whether any modifications have been made (always empty),
+* The URL by which to access the license file (assumes `master`),
+* A classification of what license this is ([using this](https://github.com/google/licenseclassifier)).
+
+
+### Check mode
+
+`dep-collector` also includes a mode that will check for "forbidden" licenses.
+
+> In order to run dep-collector in this mode, you must first run:
+>   go get github.com/google/licenseclassifier
+
+For example (failing):
+```shell
+$ dep-collector -check ./foo/bar/baz
+2018/07/20 22:01:29 Error checking license collection: Errors validating licenses:
+Found matching forbidden license in "foo.io/bar/vendor/github.com/BurntSushi/toml": WTFPL
+```
+
+For example (passing):
+
+```shell
+$ dep-collector -check .
+2018/07/20 22:29:09 No errors found.
+```

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	gb "go/build"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func CollectTransitiveImports(binaries []string) ([]string, error) {
+	// Perform a simple DFS to collect the binaries' transitive dependencies.
+	visited := make(map[string]struct{})
+	for _, importpath := range binaries {
+		if gb.IsLocalImport(importpath) {
+			ip, err := qualifyLocalImport(importpath)
+			if err != nil {
+				return nil, err
+			}
+			importpath = ip
+		}
+
+		pkg, err := gb.Import(importpath, WorkingDir, gb.ImportComment)
+		if err != nil {
+			return nil, err
+		}
+		if err := visit(pkg, visited); err != nil {
+			return nil, err
+		}
+	}
+
+	// Sort the dependencies deterministically.
+	var list sort.StringSlice
+	for ip := range visited {
+		if !strings.Contains(ip, "/vendor/") {
+			// Skip files outside of vendor
+			continue
+		}
+		list = append(list, ip)
+	}
+	list.Sort()
+
+	return list, nil
+}
+
+func qualifyLocalImport(ip string) (string, error) {
+	gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
+	if !strings.HasPrefix(WorkingDir, gopathsrc) {
+		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = %s", gopathsrc)
+	}
+	return filepath.Join(strings.TrimPrefix(WorkingDir, gopathsrc+string(filepath.Separator)), ip), nil
+}
+
+func visit(pkg *gb.Package, visited map[string]struct{}) error {
+	if _, ok := visited[pkg.ImportPath]; ok {
+		return nil
+	}
+	visited[pkg.ImportPath] = struct{}{}
+
+	for _, ip := range pkg.Imports {
+		if ip == "C" {
+			// skip cgo
+			continue
+		}
+		subpkg, err := gb.Import(ip, WorkingDir, gb.ImportComment)
+		if err != nil {
+			return fmt.Errorf("%v\n -> %v", pkg.ImportPath, err)
+		}
+		if !strings.HasPrefix(subpkg.Dir, WorkingDir) {
+			// Skip import paths outside of our workspace (std library)
+			continue
+		}
+		if err := visit(subpkg, visited); err != nil {
+			return fmt.Errorf("%v (%v)\n -> %v", pkg.ImportPath, pkg.Dir, err)
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/licenses.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/licenses.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	gb "go/build"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/licenseclassifier"
+)
+
+var LicenseNames = []string{
+	"LICENCE",
+	"LICENSE",
+	"LICENSE.code",
+	"LICENSE.md",
+	"LICENSE.txt",
+	"COPYING",
+	"copyright",
+}
+
+const MatchThreshold = 0.9
+
+type LicenseFile struct {
+	EnclosingImportPath string
+	LicensePath         string
+}
+
+func (lf *LicenseFile) Body() (string, error) {
+	body, err := ioutil.ReadFile(lf.LicensePath)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func (lt *LicenseFile) Classify(classifier *licenseclassifier.License) (string, error) {
+	body, err := lt.Body()
+	if err != nil {
+		return "", err
+	}
+	m := classifier.NearestMatch(body)
+	if m == nil {
+		return "", fmt.Errorf("unable to classify license: %v", lt.EnclosingImportPath)
+	}
+	return m.Name, nil
+}
+
+func (lt *LicenseFile) Check(classifier *licenseclassifier.License) error {
+	body, err := lt.Body()
+	if err != nil {
+		return err
+	}
+	ms := classifier.MultipleMatch(body, false)
+	for _, m := range ms {
+		return fmt.Errorf("Found matching forbidden license in %q: %v", lt.EnclosingImportPath, m.Name)
+	}
+	return nil
+}
+
+func (lt *LicenseFile) Entry() (string, error) {
+	body, err := lt.Body()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`
+===========================================================
+Import: %s
+
+%s
+`, lt.EnclosingImportPath, body), nil
+}
+
+func (lt *LicenseFile) CSVRow(classifier *licenseclassifier.License) (string, error) {
+	classification, err := lt.Classify(classifier)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(lt.EnclosingImportPath, "/vendor/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("wrong number of parts splitting import path on %q : %q", "/vendor/", lt.EnclosingImportPath)
+	}
+	return strings.Join([]string{
+		parts[1],
+		"Static",
+		"", // TODO(mattmoor): Modifications?
+		"https://" + parts[0] + "/blob/master/vendor/" + parts[1] + "/" + filepath.Base(lt.LicensePath),
+		classification,
+	}, ","), nil
+}
+
+func findLicense(ip string) (*LicenseFile, error) {
+	pkg, err := gb.Import(ip, WorkingDir, gb.ImportComment)
+	if err != nil {
+		return nil, err
+	}
+	dir := pkg.Dir
+
+	for {
+		// When we reach the root of our workspace, stop searching.
+		if dir == WorkingDir {
+			return nil, fmt.Errorf("unable to find license for %q", pkg.ImportPath)
+		}
+
+		for _, name := range LicenseNames {
+			p := filepath.Join(dir, name)
+			if _, err := os.Stat(p); err != nil {
+				continue
+			}
+
+			return &LicenseFile{
+				EnclosingImportPath: ip,
+				LicensePath:         p,
+			}, nil
+		}
+
+		// Walk to the parent directory / import path
+		dir = filepath.Dir(dir)
+		ip = filepath.Dir(ip)
+	}
+}
+
+type LicenseCollection []*LicenseFile
+
+func (lc LicenseCollection) Entries() (string, error) {
+	sections := make([]string, 0, len(lc))
+	for _, key := range lc {
+		entry, err := key.Entry()
+		if err != nil {
+			return "", err
+		}
+		sections = append(sections, entry)
+	}
+	return strings.Join(sections, "\n"), nil
+}
+
+func (lc LicenseCollection) CSV(classifier *licenseclassifier.License) (string, error) {
+	sections := make([]string, 0, len(lc))
+	for _, entry := range lc {
+		row, err := entry.CSVRow(classifier)
+		if err != nil {
+			return "", err
+		}
+		sections = append(sections, row)
+	}
+	return strings.Join(sections, "\n"), nil
+}
+
+func (lc LicenseCollection) Check(classifier *licenseclassifier.License) error {
+	errors := []string{}
+	for _, entry := range lc {
+		if err := entry.Check(classifier); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("Errors validating licenses:\n%v", strings.Join(errors, "\n"))
+}
+
+func CollectLicenses(imports []string) (LicenseCollection, error) {
+	// for each of the import paths, search for a license file.
+	licenseFiles := make(map[string]*LicenseFile)
+	for _, ip := range imports {
+		lf, err := findLicense(ip)
+		if err != nil {
+			return nil, err
+		}
+		licenseFiles[lf.EnclosingImportPath] = lf
+	}
+
+	order := sort.StringSlice{}
+	for key := range licenseFiles {
+		order = append(order, key)
+	}
+	order.Sort()
+
+	licenseTypes := LicenseCollection{}
+	for _, key := range order {
+		licenseTypes = append(licenseTypes, licenseFiles[key])
+	}
+	return licenseTypes, nil
+}

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/main.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/main.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/google/licenseclassifier"
+)
+
+var WorkingDir, _ = os.Getwd()
+
+var (
+	csv   = flag.Bool("csv", false, "Whether to print in CSV format (with slow classification).")
+	check = flag.Bool("check", false, "Whether to just check license files for forbidden licenses.")
+)
+
+func main() {
+	flag.Parse()
+	if flag.NArg() == 0 {
+		log.Fatalf("Expected a list of import paths, got: %v", flag.Args())
+	}
+
+	// Perform a simple DFS to collect the binaries' transitive dependencies.
+	transitiveImports, err := CollectTransitiveImports(flag.Args())
+	if err != nil {
+		log.Fatalf("Error collecting transitive dependencies: %v", err)
+	}
+
+	// Gather all of the license data from the imports.
+	collection, err := CollectLicenses(transitiveImports)
+	if err != nil {
+		log.Fatalf("Error identifying licenses for transitive dependencies: %v", err)
+	}
+
+	if *check {
+		classifier, err := licenseclassifier.NewWithForbiddenLicenses(MatchThreshold)
+		if err != nil {
+			log.Fatalf("Error creating license classifier: %v", err)
+		}
+		if err := collection.Check(classifier); err != nil {
+			log.Fatalf("Error checking license collection: %v", err)
+		}
+		log.Printf("No errors found.")
+		return
+	}
+
+	if *csv {
+		classifier, err := licenseclassifier.New(MatchThreshold)
+		if err != nil {
+			log.Fatalf("Error creating license classifier: %v", err)
+		}
+		output, err := collection.CSV(classifier)
+		if err != nil {
+			log.Fatalf("Error generating CSV: %v", err)
+		}
+		os.Stdout.Write([]byte(output))
+	} else {
+		entries, err := collection.Entries()
+		if err != nil {
+			log.Fatalf("Error generating entries: %v", err)
+		}
+		os.Stdout.Write([]byte(entries))
+	}
+}


### PR DESCRIPTION
Scripts that update deps needed to have `dep-collector` (and
`licenseclassifier` which it uses) vendored in order to be able to
automatically install when they are not present.

Having an older version of `dep-collector` resulted in the following
error when trying to update the vendored code:

```
`Error identifying licenses for transitive dependencies: unable to find license for "github.com/knative/build-pipeline/vendor/github.com/joho/godotenv"`
```

This is resolved in a newer version of `dep-collector`.

Unfortunately, if something like this happens again, folks will still
need to realize they have an older version of `dep-collector` and remove
it before running these scripts.

This was also fixed in build-pipeline in https://github.com/knative/build-pipeline/pull/290

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```