### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,8 +33,8 @@ $ git remote add ${USER} https://github.com/${USER}/build
 
 Configure `ko` to point to your registry:
 
-For a gcr.io project (like "myproject"), it will need to have Container
-Registry API enabled first.
+For a gcr.io project (like "myproject"), it will need to have Container Registry
+API enabled first.
 
 ```shell
 # You can put these definitions in .bashrc, so this is one-time setup.
@@ -61,7 +61,8 @@ go get -u github.com/google/go-containerregistry/cmd/ko
 which ko
 ```
 
-Note that this expects your Docker authorization is [properly configured](https://cloud.google.com/container-registry/docs/advanced-authentication#standalone_docker_credential_helper).
+Note that this expects your Docker authorization is
+[properly configured](https://cloud.google.com/container-registry/docs/advanced-authentication#standalone_docker_credential_helper).
 
 ### Standing it up
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ address a common need for cloud native development.
 
 A Knative build extends
 [Kubernetes](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
-and utilizes existing Kubernetes primitives to provide you with the
-ability to run on-cluster container builds from source. For example, you can
-write a build that uses Kubernetes-native resources to obtain your source code
-from a repository, build a container image, then run that image.
+and utilizes existing Kubernetes primitives to provide you with the ability to
+run on-cluster container builds from source. For example, you can write a build
+that uses Kubernetes-native resources to obtain your source code from a
+repository, build a container image, then run that image.
 
 While Knative builds are optimized for building, testing, and deploying source
 code, you are still responsible for developing the corresponding components
@@ -24,9 +24,9 @@ that:
 - Build container images.
 - Push container images to an image registry, or deploy them to a cluster.
 
-The goal of a Knative build is to provide a standard, portable, reusable,
-and performance optimized method for defining and running on-cluster container
-image builds. By providing the “boring but difficult” task of running builds on
+The goal of a Knative build is to provide a standard, portable, reusable, and
+performance optimized method for defining and running on-cluster container image
+builds. By providing the “boring but difficult” task of running builds on
 Kubernetes, Knative saves you from having to independently develop and reproduce
 these common Kubernetes-based development processes.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -5,9 +5,9 @@
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
@@ -37,11 +37,11 @@ Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
 
 ## Scope
 
@@ -54,14 +54,13 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by contacting the project team at
-knative-code-of-conduct@googlegroups.com. All complaints will be reviewed
-and investigated and will result in a response that is deemed
-necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of
-an incident. Further details of specific enforcement policies may be
-posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+knative-code-of-conduct@googlegroups.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -69,7 +68,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,9 +1,12 @@
 # Assorted scripts for development
 
-This directory contains several scripts useful in the development process of Knative Build.
+This directory contains several scripts useful in the development process of
+Knative Build.
 
-- `boilerplate/add-boilerplate.sh` Adds license boilerplate to _txt_ or _go_ files in a directory, recursively.
+- `boilerplate/add-boilerplate.sh` Adds license boilerplate to _txt_ or _go_
+  files in a directory, recursively.
 - `release.sh` Creates a new [release](release.md) of Knative Build.
 - `update-codegen.sh` Updates auto-generated client libraries.
 - `update-deps.sh` Updates Go dependencies.
-- `verify-codegen.sh` Verifies that auto-generated client libraries are up-to-date.
+- `verify-codegen.sh` Verifies that auto-generated client libraries are
+  up-to-date.

--- a/hack/release.md
+++ b/hack/release.md
@@ -1,36 +1,35 @@
 # Creating a new Knative Build release
 
-The `release.sh` script automates the creation of Knative Build releases,
-either nightly or versioned ones.
+The `release.sh` script automates the creation of Knative Build releases, either
+nightly or versioned ones.
 
 By default, the script creates a nightly release but does not publish anywhere.
 
 ## Common flags for cutting releases
 
-The following flags affect the behavior of the script, no matter the type of
-the release.
+The following flags affect the behavior of the script, no matter the type of the
+release.
 
-- `--skip-tests` Do not run tests before building the release. Otherwise,
-  build, unit and end-to-end tests are run and they all must pass for the
-  release to be built.
-- `--tag-release`, `--notag-release` Tag (or not) the generated images
-  with either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or
-  `vX.Y.Z` for versioned releases. _For versioned releases, a tag is always
-  added._
-- `--publish`, `--nopublish` Whether the generated images should be published
-  to a GCR, and the generated manifests written to a GCS bucket or not. If yes,
-  the destination GCR is defined by the environment variable
-  `$BUILD_RELEASE_GCR` (defaults to `gcr.io/knative-nightly`) and the
-  destination GCS bucket is defined by the environment variable
-  `$BUILD_RELEASE_GCS` (defaults to `knative-nightly/build`). If no, the
-  images will be pushed to the `ko.local` registry, and the manifests written
-  to the local disk only (in the repository root directory).
+- `--skip-tests` Do not run tests before building the release. Otherwise, build,
+  unit and end-to-end tests are run and they all must pass for the release to be
+  built.
+- `--tag-release`, `--notag-release` Tag (or not) the generated images with
+  either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
+  versioned releases. _For versioned releases, a tag is always added._
+- `--publish`, `--nopublish` Whether the generated images should be published to
+  a GCR, and the generated manifests written to a GCS bucket or not. If yes, the
+  destination GCR is defined by the environment variable `$BUILD_RELEASE_GCR`
+  (defaults to `gcr.io/knative-nightly`) and the destination GCS bucket is
+  defined by the environment variable `$BUILD_RELEASE_GCS` (defaults to
+  `knative-nightly/build`). If no, the images will be pushed to the `ko.local`
+  registry, and the manifests written to the local disk only (in the repository
+  root directory).
 
 ## Creating nightly releases
 
 Nightly releases are built against the current git tree. The behavior of the
-script is defined by the common flags. You must have write access to the GCR
-and GCS bucket the release will be pushed to, unless `--nopublish` is used.
+script is defined by the common flags. You must have write access to the GCR and
+GCS bucket the release will be pushed to, unless `--nopublish` is used.
 
 Examples:
 
@@ -67,6 +66,6 @@ for your GitHub username, password, and possibly 2-factor authentication
 challenge before the release is published.
 
 The release will be published in the _Releases_ page of the Knative Build
-repository, with the title _Knative Build release vX.Y.Z_ and the given
-release notes. It will also be tagged _vX.Y.Z_ (both on GitHub and as a git
-annotated tag).
+repository, with the title _Knative Build release vX.Y.Z_ and the given release
+notes. It will also be tagged _vX.Y.Z_ (both on GitHub and as a git annotated
+tag).

--- a/roadmap-2018.md
+++ b/roadmap-2018.md
@@ -20,8 +20,8 @@ In more detail:
 ## Detection
 
 Users shouldn't have to know explicitly which version of a build template
-they're using; they have source, they want to build and a container image.
-In the middle of that, before building, is **detection**.
+they're using; they have source, they want to build and a container image. In
+the middle of that, before building, is **detection**.
 
 How this works in real life is a hard problem, that a lot of smart people have
 spent a lot of their smarts working on it. How that fits into the Build
@@ -42,33 +42,31 @@ examples of how to produce a good build template, and to encourage users to
 contribute their own.
 
 Templates should, as much as possible, take advantage of some of the conceptual
-advances we've made with FTL-like layer caching techniques, [remote image
-rebasing](https://github.com/google/image-rebase), source detection, and in
-general be best-in-class in terms of fast incremental builds.
+advances we've made with FTL-like layer caching techniques,
+[remote image rebasing](https://github.com/google/image-rebase), source
+detection, and in general be best-in-class in terms of fast incremental builds.
 
 [GCB](cloud.google.com/container-builder/docs) already maintains a set of
-[officially-supported
-builders](https://github.com/GoogleCloudPlatform/cloud-builders), and some
-[contributed by community
-members](https://github.com/GoogleCloudPlatform/cloud-builders-community). We'd
-be happy to contribute any of these for which there is demand. CloudFoundry has
-done some very exciting work to start supporting buildpacks. Other interested
-parties should have a central place to contribute and advertise their support,
-and that repository should be discoverable and useful to end users.
+[officially-supported builders](https://github.com/GoogleCloudPlatform/cloud-builders),
+and some
+[contributed by community members](https://github.com/GoogleCloudPlatform/cloud-builders-community).
+We'd be happy to contribute any of these for which there is demand. CloudFoundry
+has done some very exciting work to start supporting buildpacks. Other
+interested parties should have a central place to contribute and advertise their
+support, and that repository should be discoverable and useful to end users.
 
 ## Workflow
 
 Today, a Build expresses a list of step containers to run in order, to
 completion. We believe this covers many common build use cases, but some users
-will inevitably want to layer on more complex build workflows, and we should
-try to enable that.
+will inevitably want to layer on more complex build workflows, and we should try
+to enable that.
 
 Features we've identified that users might want to include in their build
 workflows:
 
 - Parallel execution (fan-out/fan-in)
-- Conditional step execution ("only execute step X if Git branch ==
-  'master'")
+- Conditional step execution ("only execute step X if Git branch == 'master'")
 - Retry steps ("run step X up to three times until it succeeds")
 - Runtime-conditional step execution ("only execute step Y if step X failed";
   e.g., recover/cleanup a broken rollout)
@@ -96,19 +94,19 @@ The Build CRD is powerful, but far from perfect.
 
 In particular, settling on a standard for expressing a secure and reliable
 persistent caching solution for build inputs and artifacts, supported by build
-templates and builder images, could greatly improve build speeds and reduce
-cost to users.
+templates and builder images, could greatly improve build speeds and reduce cost
+to users.
 
 ## Integrations
 
 The Build CRD provides a useful model for expressing a build which produces a
 container image, and a lot of the adjacent technologies (FTL, buildpacks,
 dockerless rebasing, etc.) can be useful to other projects as well.
-[Skaffold](https://github.com/GoogleCloudPlatform/skaffold), for instance,
-could benefit from adopting the Build CRD build model.
+[Skaffold](https://github.com/GoogleCloudPlatform/skaffold), for instance, could
+benefit from adopting the Build CRD build model.
 
 There are also gains to be made from integrating Build CRD with other services,
-such as [Grafeas](https://grafeas.io), which we can use to record metadata
-about containers produced during a build.
+such as [Grafeas](https://grafeas.io), which we can use to record metadata about
+containers produced during a build.
 
 We should explore these integrations, and others as they become relevant.

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,8 @@
 
 This directory contains tests and testing docs for `Knative Build`:
 
-- [Unit tests](#running-unit-tests) currently reside in the codebase alongside the code they test
+- [Unit tests](#running-unit-tests) currently reside in the codebase alongside
+  the code they test
 - [End-to-end tests](#running-end-to-end-tests), of which there are two types:
 
 ## Running unit tests
@@ -13,7 +14,8 @@ To run all unit tests:
 go test ./...
 ```
 
-_By default `go test` will not run [the e2e tests](#running-end-to-end-tests), which need [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
+_By default `go test` will not run [the e2e tests](#running-end-to-end-tests),
+which need [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
 
 ## Running end to end tests
 
@@ -21,14 +23,18 @@ _By default `go test` will not run [the e2e tests](#running-end-to-end-tests), w
 
 Setting up a running `Knative Build` cluster.
 
-1. A Kubernetes cluster v1.10 or newer with the `MutatingAdmissionWebhook` admission controller enabled. `kubectl` v1.10 is also required. [see here](https://github.com/knative/docs/blob/master/install/Knative-with-any-k8s.md)
+1. A Kubernetes cluster v1.10 or newer with the `MutatingAdmissionWebhook`
+   admission controller enabled. `kubectl` v1.10 is also required.
+   [see here](https://github.com/knative/docs/blob/master/install/Knative-with-any-k8s.md)
 
-1. Configure `ko` to point to your registry. [see here](https://github.com/knative/build/blob/master/DEVELOPMENT.md#one-time-setup)
+1. Configure `ko` to point to your registry.
+   [see here](https://github.com/knative/build/blob/master/DEVELOPMENT.md#one-time-setup)
 
 ### Go e2e tests
 
-To run [the Go e2e tests](./e2e), you need to have a running environment that meets
-[the e2e test environment requirements](#environment-requirements) and [stand up a version of this controller on-cluster](https://github.com/knative/build/blob/master/DEVELOPMENT.md#standing-it-up).
+To run [the Go e2e tests](./e2e), you need to have a running environment that
+meets [the e2e test environment requirements](#environment-requirements) and
+[stand up a version of this controller on-cluster](https://github.com/knative/build/blob/master/DEVELOPMENT.md#standing-it-up).
 
 Finally run the Go e2e tests with the build tag `e2e`.
 
@@ -36,7 +42,8 @@ Finally run the Go e2e tests with the build tag `e2e`.
 go test -v -tags=e2e -count=1 ./test/e2e/...
 ```
 
-`-count=1` is the idiomatic way to bypass test caching, so that tests will always run.
+`-count=1` is the idiomatic way to bypass test caching, so that tests will
+always run.
 
 ### YAML e2e tests
 
@@ -49,7 +56,8 @@ To run the YAML e2e tests, you need to have a running environment that meets
 
 ### One test case
 
-To run one e2e test case, e.g. TestSimpleBuild, use [the `-run` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags):
+To run one e2e test case, e.g. TestSimpleBuild, use
+[the `-run` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags):
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e/... -run=<regex>

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -4,13 +4,17 @@
 
 ## Adding end to end tests
 
-Knative Build e2e tests [test the end to end functionality of the Knative Build API](#requirements) to verify the behavior of this specific implementation.
+Knative Build e2e tests
+[test the end to end functionality of the Knative Build API](#requirements) to
+verify the behavior of this specific implementation.
 
 ### Requirements
 
-The e2e tests are used to test whether the flow of Knative Build is performing as designed from start to finish.
+The e2e tests are used to test whether the flow of Knative Build is performing
+as designed from start to finish.
 
 The e2e tests **MUST**:
 
-1. Provide frequent output describing what actions they are undertaking, especially before performing long running operations.
+1. Provide frequent output describing what actions they are undertaking,
+   especially before performing long running operations.
 2. Follow Golang best practices.


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`