### PR TITLE
Format markdown

### DIFF
--- a/hack/release.md
+++ b/hack/release.md
@@ -8,28 +8,27 @@ anywhere.
 
 ## Common flags for cutting releases
 
-The following flags affect the behavior of the script, no matter the type of
-the release.
+The following flags affect the behavior of the script, no matter the type of the
+release.
 
-- `--skip-tests` Do not run tests before building the release. Otherwise,
-  build, unit and end-to-end tests are run and they all must pass for the
-  release to be built.
-- `--tag-release`, `--notag-release` Tag (or not) the generated images
-  with either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or
-  `vX.Y.Z` for versioned releases. _For versioned releases, a tag is always
-  added._
-- `--release-gcs` Defines the GCS bucket where the manifests will be stored.
-  By default, this is `knative-nightly/build`. This flag is ignored if the
-  release is not being published.
+- `--skip-tests` Do not run tests before building the release. Otherwise, build,
+  unit and end-to-end tests are run and they all must pass for the release to be
+  built.
+- `--tag-release`, `--notag-release` Tag (or not) the generated images with
+  either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
+  versioned releases. _For versioned releases, a tag is always added._
+- `--release-gcs` Defines the GCS bucket where the manifests will be stored. By
+  default, this is `knative-nightly/build`. This flag is ignored if the release
+  is not being published.
 - `--release-gcr` Defines the GCR where the images will be stored. By default,
   this is `gcr.io/knative-nightly`. This flag is ignored if the release is not
   being published.
-- `--publish`, `--nopublish` Whether the generated images should be published
-  to a GCR, and the generated manifests written to a GCS bucket or not. If yes,
-  the `--release-gcs` and `--release-gcr` flags can be used to change the
-  default values of the GCR/GCS used. If no, the images will be pushed to the
-  `ko.local` registry, and the manifests written to the local disk only (in the
-  repository root directory).
+- `--publish`, `--nopublish` Whether the generated images should be published to
+  a GCR, and the generated manifests written to a GCS bucket or not. If yes, the
+  `--release-gcs` and `--release-gcr` flags can be used to change the default
+  values of the GCR/GCS used. If no, the images will be pushed to the `ko.local`
+  registry, and the manifests written to the local disk only (in the repository
+  root directory).
 
 ## Creating nightly releases
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`