### PR TITLE
Amended docs for using docker hub with KO_DOCKER_REPO

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,6 +43,11 @@ API enabled first.
 # will be pushed, including hostname.
 export KO_DOCKER_REPO=us.gcr.io/<myproject>
 ```
+**Note**: if you are using docker hub to store your images your
+     `KO_DOCKER_REPO` variable should be `docker.io/<username>`.
+
+**Note**: Currently Docker Hub doesn't let you create subdirs under your
+     username.
 
 For a local registry (using insecure http://) it needs to be on localhost:
 


### PR DESCRIPTION
Fixes #

Found docs in `serving/development.md` regarding using docker hub with`KO_DOCKER_REPO` and amended the `build/development.md` docs with the information.

Using ```hub.docker/r/<username>/<repo-name>``` gives a 404 error when running `ko apply config/`
## Proposed Changes

* Amend `DEVELOPMENT.md` with docker hub usage instructions with `ko` - specifically for `KO_DOCKER_REPO`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE

```

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
