### PR TITLE
fix (build_validation) Incorrect field paths returned

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -315,7 +315,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:e3707aeaccd2adc89eba6c062fec72116fe1fc1ba71097da85b4d8ae1668a675"
+  digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "NUT"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -225,7 +225,7 @@
   revision = "f0d7bb60956f88d4743f5fea66b5607b96d262c9"
 
 [[projects]]
-  digest = "1:30457e774f9117d31aac140bed69fa62594f5c99af9932fb4f9fb1c427ffc1df"
+  digest = "1:e7222d1d533f87f6115cb15eb64faac9501226803d1bd7fca8f8640d71d02eb5"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -245,7 +245,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "088e3f7faf9d7ed0122937f66289cc050d0a78b0"
+  revision = "585076ba67e86ccbe9c2c146d49502d7433da7c0"
 
 [[projects]]
   branch = "master"
@@ -315,7 +315,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
+  digest = "1:e3707aeaccd2adc89eba6c062fec72116fe1fc1ba71097da85b4d8ae1668a675"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "NUT"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,8 +47,8 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-11-06
-  revision = "088e3f7faf9d7ed0122937f66289cc050d0a78b0"
+  # HEAD as of 2018-12-09
+  revision = "585076ba67e86ccbe9c2c146d49502d7433da7c0"
 
 [prune]
   go-tests = true

--- a/pkg/apis/build/v1alpha1/build_template_validation.go
+++ b/pkg/apis/build/v1alpha1/build_template_validation.go
@@ -66,7 +66,7 @@ func validateSteps(steps []corev1.Container) *apis.FieldError {
 			continue
 		}
 		if _, ok := names[s.Name]; ok {
-			return apis.ErrMultipleOneOf("stepName")
+			return apis.ErrMultipleOneOf("name")
 		}
 		names[s.Name] = struct{}{}
 	}

--- a/pkg/apis/build/v1alpha1/build_template_validation.go
+++ b/pkg/apis/build/v1alpha1/build_template_validation.go
@@ -47,7 +47,7 @@ func ValidateVolumes(volumes []corev1.Volume) *apis.FieldError {
 	vols := map[string]struct{}{}
 	for _, v := range volumes {
 		if _, ok := vols[v.Name]; ok {
-			return apis.ErrMultipleOneOf("volumeName")
+			return apis.ErrMultipleOneOf("name")
 		}
 		vols[v.Name] = struct{}{}
 	}

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -36,11 +36,6 @@ func (bs *BuildSpec) Validate() *apis.FieldError {
 	if bs.Template != nil && len(bs.Steps) > 0 {
 		return apis.ErrMultipleOneOf("template", "steps")
 	}
-	//removing below conditional because bs.Template.Name is already being checked in bs.Template.Validate()
-
-	//if bs.Template != nil && bs.Template.Name == "" {
-	//	apis.ErrMissingField("name").ViaField("template")
-	//}
 
 	// If a build specifies a template, all the template's parameters without
 	// defaults must be satisfied by the build's parameters.
@@ -48,15 +43,15 @@ func (bs *BuildSpec) Validate() *apis.FieldError {
 		return bs.Template.Validate().ViaField("template")
 	}
 
-	//below method potentially has a bug:
-	//it does not Validate if only a "Source" has been set, it only validates if multiple sources have been set
+	// Below method potentially has a bug:
+	// It does not Validate if only a "Source" has been set, it only validates if multiple sources have been set
 	return bs.validateSources().
 		Also(ValidateVolumes(bs.Volumes)).
 		Also(bs.validateTimeout()).
 		Also(validateSteps(bs.Steps))
 }
 
-// Validate templateKind
+// Validate template
 func (b *TemplateInstantiationSpec) Validate() *apis.FieldError {
 	if b == nil {
 		return nil
@@ -100,16 +95,16 @@ func (bs BuildSpec) validateSources() *apis.FieldError {
 		nodeMap: map[string]map[string]string{},
 	}
 
-	// both source and sources cannot be defined in build
+	// Both source and sources cannot be defined in build
 	if len(bs.Sources) > 0 && bs.Source != nil {
 		return apis.ErrMultipleOneOf("source", "sources")
 	}
 	for _, source := range bs.Sources {
-		// check all source have unique names
+		// Check all source have unique names
 		if _, ok := names[source.Name]; ok {
 			return apis.ErrMultipleOneOf("name").ViaField("sources")
 		}
-		// multiple sources cannot have subpath defined
+		// Multiple sources cannot have subpath defined
 		if source.SubPath != "" {
 			if subPathExists {
 				return apis.ErrInvalidValue(source.SubPath, "subpath").ViaField("sources")

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/knative/pkg/apis"
@@ -78,10 +77,8 @@ func (bs *BuildSpec) validateTimeout() *apis.FieldError {
 	}
 	maxTimeout := time.Duration(24 * time.Hour)
 
-	if bs.Timeout.Duration > maxTimeout {
-		return apis.ErrInvalidValue(fmt.Sprintf("%s should be < 24h", bs.Timeout), "timeout")
-	} else if bs.Timeout.Duration < 0 {
-		return apis.ErrInvalidValue(fmt.Sprintf("%s should be > 0", bs.Timeout), "timeout")
+	if bs.Timeout.Duration > maxTimeout || bs.Timeout.Duration < 0 {
+		return apis.ErrOutOfBoundsValue(bs.Timeout.Duration.String(), "0", "24", "timeout")
 	}
 	return nil
 }

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -81,7 +81,7 @@ func (b *TemplateInstantiationSpec) Validate() *apis.FieldError {
 			BuildTemplateKind:
 			return nil
 		default:
-			return apis.ErrInvalidValue(string(b.Kind), apis.CurrentField)
+			return apis.ErrInvalidValue(string(b.Kind), "kind").ViaField("template")
 		}
 	}
 	return nil

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -107,12 +107,12 @@ func (bs BuildSpec) validateSources() *apis.FieldError {
 	for _, source := range bs.Sources {
 		// check all source have unique names
 		if _, ok := names[source.Name]; ok {
-			return apis.ErrMultipleOneOf("name").ViaField("source").ViaField("sources")
+			return apis.ErrMultipleOneOf("name").ViaField("sources")
 		}
 		// multiple sources cannot have subpath defined
 		if source.SubPath != "" {
 			if subPathExists {
-				return apis.ErrInvalidValue(source.SubPath, "subpath").ViaField("source").ViaField("sources")
+				return apis.ErrInvalidValue(source.SubPath, "subpath").ViaField("sources")
 			}
 			subPathExists = true
 		}
@@ -123,12 +123,12 @@ func (bs BuildSpec) validateSources() *apis.FieldError {
 				continue
 			}
 			if emptyTargetPath {
-				return apis.ErrInvalidValue("Empty Target Path", "targetPath").ViaField("source").ViaField("sources")
+				return apis.ErrInvalidValue("Empty Target Path", "targetPath").ViaField("sources")
 			}
 			emptyTargetPath = true
 		} else {
 			if source.Custom != nil {
-				return apis.ErrInvalidValue(source.TargetPath, "targetPath").ViaField("source").ViaField("sources")
+				return apis.ErrInvalidValue(source.TargetPath, "targetPath").ViaField("sources")
 			}
 			if err := insertNode(source.TargetPath, pathtree); err != nil {
 				return err

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -48,7 +48,7 @@ func (bs *BuildSpec) Validate() *apis.FieldError {
 	return bs.validateSources().
 		Also(ValidateVolumes(bs.Volumes)).
 		Also(bs.validateTimeout()).
-		Also(validateSteps(bs.Steps))
+		Also(validateSteps(bs.Steps).ViaField("steps"))
 }
 
 // Validate template
@@ -107,7 +107,7 @@ func (bs BuildSpec) validateSources() *apis.FieldError {
 		// Multiple sources cannot have subpath defined
 		if source.SubPath != "" {
 			if subPathExists {
-				return apis.ErrInvalidValue(source.SubPath, "subpath").ViaField("sources")
+				return apis.ErrMultipleOneOf("subpath").ViaField("sources")
 			}
 			subPathExists = true
 		}

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -34,7 +34,7 @@ func (bs *BuildSpec) Validate() *apis.FieldError {
 		return apis.ErrMissingField("b.spec.template").Also(apis.ErrMissingField("b.spec.steps"))
 	}
 	if bs.Template != nil && len(bs.Steps) > 0 {
-		return apis.ErrDisallowedFields("b.spec.steps")
+		return apis.ErrMultipleOneOf("template", "steps")
 	}
 
 	if bs.Template != nil && bs.Template.Name == "" {

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -34,7 +34,7 @@ func (bs *BuildSpec) Validate() *apis.FieldError {
 		return apis.ErrMissingField("b.spec.template").Also(apis.ErrMissingField("b.spec.steps"))
 	}
 	if bs.Template != nil && len(bs.Steps) > 0 {
-		return apis.ErrMissingField("b.spec.template").Also(apis.ErrMissingField("b.spec.steps"))
+		return apis.ErrDisallowedFields("b.spec.steps")
 	}
 
 	if bs.Template != nil && bs.Template.Name == "" {

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -46,7 +46,7 @@ func (bs *BuildSpec) Validate() *apis.FieldError {
 	// Below method potentially has a bug:
 	// It does not Validate if only a "Source" has been set, it only validates if multiple sources have been set
 	return bs.validateSources().
-		Also(ValidateVolumes(bs.Volumes)).
+		Also(ValidateVolumes(bs.Volumes).ViaField("volumes")).
 		Also(bs.validateTimeout()).
 		Also(validateSteps(bs.Steps).ViaField("steps"))
 }

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -125,7 +125,7 @@ func (bs BuildSpec) validateSources() *apis.FieldError {
 			if source.Custom != nil {
 				return apis.ErrInvalidValue(source.TargetPath, "targetPath").ViaField("sources")
 			}
-			if err := insertNode(source.TargetPath, pathtree); err != nil {
+			if err := insertNode(source.TargetPath, pathtree).ViaField("sources"); err != nil {
 				return err
 			}
 		}

--- a/pkg/apis/build/v1alpha1/build_validation.go
+++ b/pkg/apis/build/v1alpha1/build_validation.go
@@ -31,7 +31,7 @@ func (b *Build) Validate() *apis.FieldError {
 // Validate for build spec
 func (bs *BuildSpec) Validate() *apis.FieldError {
 	if bs.Template == nil && len(bs.Steps) == 0 {
-		return apis.ErrMissingField("b.spec.template").Also(apis.ErrMissingField("b.spec.steps"))
+		return apis.ErrMissingOneOf("template", "steps")
 	}
 	if bs.Template != nil && len(bs.Steps) > 0 {
 		return apis.ErrMultipleOneOf("template", "steps")
@@ -108,7 +108,7 @@ func (bs BuildSpec) validateSources() *apis.FieldError {
 
 	// both source and sources cannot be defined in build
 	if len(bs.Sources) > 0 && bs.Source != nil {
-		return apis.ErrMultipleOneOf("b.spec.source", "b.spec.sources")
+		return apis.ErrMultipleOneOf("source", "sources")
 	}
 
 	for _, source := range bs.Sources {

--- a/pkg/apis/build/v1alpha1/build_validation_test.go
+++ b/pkg/apis/build/v1alpha1/build_validation_test.go
@@ -338,7 +338,7 @@ func TestValidateBuild(t *testing.T) {
 				}},
 			},
 		},
-		want: apis.ErrInvalidValue("&Duration{Duration:-48h0m0s,} should be > 0", "spec.timeout"),
+		want: apis.ErrOutOfBoundsValue("-48h0m0s", "0", "24", "spec.timeout"),
 	}, {
 		name: "No template and steps",
 		build: &Build{
@@ -368,7 +368,7 @@ func TestValidateBuild(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "Maximum build timeout",
+		name: "Greater than maximum build timeout",
 		build: &Build{
 			Spec: BuildSpec{
 				Timeout: &metav1.Duration{Duration: 48 * time.Hour},
@@ -378,7 +378,7 @@ func TestValidateBuild(t *testing.T) {
 				}},
 			},
 		},
-		want: apis.ErrInvalidValue("&Duration{Duration:48h0m0s,} should be < 24h", "spec.timeout"),
+		want: apis.ErrOutOfBoundsValue("48h0m0s", "0", "24", "spec.timeout"),
 	}, {
 		name: "5 minute build timeout",
 		build: &Build{

--- a/pkg/apis/build/v1alpha1/target_path_validation.go
+++ b/pkg/apis/build/v1alpha1/target_path_validation.go
@@ -28,7 +28,10 @@ type pathTree struct {
 // insertNode functions checks the path does not have overlap with existing
 // paths in path.nodeMap. If not it creates a key for path and adds
 func insertNode(path string, pathtree pathTree) *apis.FieldError {
-	err := apis.ErrMultipleOneOf("b.spec.sources.targetPath")
+	err := &apis.FieldError{
+		Message: "Overlapping Target Paths",
+		Paths:   []string{"targetPath"},
+	}
 	path = strings.Trim(path, "/")
 	parts := strings.Split(path, "/")
 

--- a/pkg/apis/build/v1alpha1/target_path_validation_test.go
+++ b/pkg/apis/build/v1alpha1/target_path_validation_test.go
@@ -23,14 +23,20 @@ func TestValidateTargetPaths(t *testing.T) {
 			"a/b/c/d",
 			"a/b",
 		},
-		wantErr: apis.ErrMultipleOneOf("b.spec.sources.targetPath"),
+		wantErr: &apis.FieldError{
+			Message: "Overlapping Target Paths",
+			Paths:   []string{"targetPath"},
+		},
 	}, {
 		desc: "paths with overlap in different order",
 		paths: []string{
 			"a/b",
 			"a/b/c",
 		},
-		wantErr: apis.ErrMultipleOneOf("b.spec.sources.targetPath"),
+		wantErr: &apis.FieldError{
+			Message: "Overlapping Target Paths",
+			Paths:   []string{"targetPath"},
+		},
 	}, {
 		desc: "paths with leaf node overlap",
 		paths: []string{
@@ -56,7 +62,10 @@ func TestValidateTargetPaths(t *testing.T) {
 			"a/b/c",
 			"a/b/c",
 		},
-		wantErr: apis.ErrMultipleOneOf("b.spec.sources.targetPath"),
+		wantErr: &apis.FieldError{
+			Message: "Overlapping Target Paths",
+			Paths:   []string{"targetPath"},
+		},
 	}, {
 		desc: "paths with same length and different leaf node",
 		paths: []string{
@@ -69,14 +78,20 @@ func TestValidateTargetPaths(t *testing.T) {
 			"github.com/foo/bar",
 			"github.com/foo/",
 		},
-		wantErr: apis.ErrMultipleOneOf("b.spec.sources.targetPath"),
+		wantErr: &apis.FieldError{
+			Message: "Overlapping Target Paths",
+			Paths:   []string{"targetPath"},
+		},
 	}, {
 		desc: "paths with overlap in different order",
 		paths: []string{
 			"github.com/foo",
 			"github.com/foo/bar",
 		},
-		wantErr: apis.ErrMultipleOneOf("b.spec.sources.targetPath"),
+		wantErr: &apis.FieldError{
+			Message: "Overlapping Target Paths",
+			Paths:   []string{"targetPath"},
+		},
 	}, {
 		desc: "paths with different leaf",
 		paths: []string{
@@ -97,7 +112,10 @@ func TestValidateTargetPaths(t *testing.T) {
 			"/dir/a",
 			"/dir/a/b",
 		},
-		wantErr: apis.ErrMultipleOneOf("b.spec.sources.targetPath"),
+		wantErr: &apis.FieldError{
+			Message: "Overlapping Target Paths",
+			Paths:   []string{"targetPath"},
+		},
 	}, {
 		desc: "paths with different parent node",
 		paths: []string{
@@ -112,7 +130,10 @@ func TestValidateTargetPaths(t *testing.T) {
 			"a/d",
 			"a/d",
 		},
-		wantErr: apis.ErrMultipleOneOf("b.spec.sources.targetPath"),
+		wantErr: &apis.FieldError{
+			Message: "Overlapping Target Paths",
+			Paths:   []string{"targetPath"},
+		},
 	}, {
 		desc: "paths starts with combination of / and no /",
 		paths: []string{
@@ -125,7 +146,10 @@ func TestValidateTargetPaths(t *testing.T) {
 			"/a/a/b/d",
 			"a/a",
 		},
-		wantErr: apis.ErrMultipleOneOf("b.spec.sources.targetPath"),
+		wantErr: &apis.FieldError{
+			Message: "Overlapping Target Paths",
+			Paths:   []string{"targetPath"},
+		},
 	}, {
 		desc: "paths with repeating nodes",
 		paths: []string{

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -1,3 +1,8 @@
+
+===========================================================
+Import: github.com/knative/build/vendor/cloud.google.com/go
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -4620,4 +4625,3 @@ Import: github.com/knative/build/vendor/k8s.io/client-go
    See the License for the specific language governing permissions and
    limitations under the License.
 
-=======

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -1,8 +1,3 @@
-
-===========================================================
-Import: github.com/knative/build/vendor/cloud.google.com/go
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -4625,3 +4620,4 @@ Import: github.com/knative/build/vendor/k8s.io/client-go
    See the License for the specific language governing permissions and
    limitations under the License.
 
+=======

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/addressable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/addressable_types.go
@@ -37,7 +37,6 @@ type Addressable struct {
 	Hostname string `json:"hostname,omitempty"`
 }
 
-
 // Addressable is an Implementable "duck type".
 var _ duck.Implementable = (*Addressable)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/condition_set.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/condition_set.go
@@ -62,7 +62,7 @@ type ConditionManager interface {
 	SetCondition(new Condition)
 
 	// MarkTrue sets the status of t to true, and then marks the happy condition to
-	// true if all other dependents are also true.
+	// true if all dependents are true.
 	MarkTrue(t ConditionType)
 
 	// MarkUnknown sets the status of t to Unknown and also sets the happy condition
@@ -82,12 +82,14 @@ type ConditionManager interface {
 
 // NewLivingConditionSet returns a ConditionSet to hold the conditions for the
 // living resource. ConditionReady is used as the happy condition.
+// The set of condition types provided are those of the terminal subconditions.
 func NewLivingConditionSet(d ...ConditionType) ConditionSet {
 	return newConditionSet(ConditionReady, d...)
 }
 
 // NewBatchConditionSet returns a ConditionSet to hold the conditions for the
 // batch resource. ConditionSucceeded is used as the happy condition.
+// The set of condition types provided are those of the terminal subconditions.
 func NewBatchConditionSet(d ...ConditionType) ConditionSet {
 	return newConditionSet(ConditionSucceeded, d...)
 }
@@ -209,13 +211,30 @@ func (r conditionsImpl) SetCondition(new Condition) {
 	r.accessor.SetConditions(conditions)
 }
 
+func (r conditionsImpl) isTerminal(t ConditionType) bool {
+	for _, cond := range append(r.dependents, r.happy) {
+		if cond == t {
+			return true
+		}
+	}
+	return false
+}
+
+func (r conditionsImpl) severity(t ConditionType) ConditionSeverity {
+	if r.isTerminal(t) {
+		return ConditionSeverityError
+	}
+	return ConditionSeverityInfo
+}
+
 // MarkTrue sets the status of t to true, and then marks the happy condition to
 // true if all other dependents are also true.
 func (r conditionsImpl) MarkTrue(t ConditionType) {
 	// set the specified condition
 	r.SetCondition(Condition{
-		Type:   t,
-		Status: corev1.ConditionTrue,
+		Type:     t,
+		Status:   corev1.ConditionTrue,
+		Severity: r.severity(t),
 	})
 
 	// check the dependents.
@@ -229,8 +248,9 @@ func (r conditionsImpl) MarkTrue(t ConditionType) {
 
 	// set the happy condition
 	r.SetCondition(Condition{
-		Type:   r.happy,
-		Status: corev1.ConditionTrue,
+		Type:     r.happy,
+		Status:   corev1.ConditionTrue,
+		Severity: r.severity(r.happy),
 	})
 }
 
@@ -239,13 +259,15 @@ func (r conditionsImpl) MarkTrue(t ConditionType) {
 func (r conditionsImpl) MarkUnknown(t ConditionType, reason, messageFormat string, messageA ...interface{}) {
 	// set the specified condition
 	r.SetCondition(Condition{
-		Type:    t,
-		Status:  corev1.ConditionUnknown,
-		Reason:  reason,
-		Message: fmt.Sprintf(messageFormat, messageA...),
+		Type:     t,
+		Status:   corev1.ConditionUnknown,
+		Reason:   reason,
+		Message:  fmt.Sprintf(messageFormat, messageA...),
+		Severity: r.severity(t),
 	})
 
 	// check the dependents.
+	isDependent := false
 	for _, cond := range r.dependents {
 		c := r.GetCondition(cond)
 		// Failed conditions trump Unknown conditions
@@ -257,28 +279,39 @@ func (r conditionsImpl) MarkUnknown(t ConditionType, reason, messageFormat strin
 			}
 			return
 		}
+		if cond == t {
+			isDependent = true
+		}
 	}
 
-	// set the happy condition
-	r.SetCondition(Condition{
-		Type:    r.happy,
-		Status:  corev1.ConditionUnknown,
-		Reason:  reason,
-		Message: fmt.Sprintf(messageFormat, messageA...),
-	})
+	if isDependent {
+		// set the happy condition, if it is one of our dependent subconditions.
+		r.SetCondition(Condition{
+			Type:     r.happy,
+			Status:   corev1.ConditionUnknown,
+			Reason:   reason,
+			Message:  fmt.Sprintf(messageFormat, messageA...),
+			Severity: r.severity(r.happy),
+		})
+	}
 }
 
 // MarkFalse sets the status of t and the happy condition to False.
 func (r conditionsImpl) MarkFalse(t ConditionType, reason, messageFormat string, messageA ...interface{}) {
-	for _, t := range []ConditionType{
-		t,
-		r.happy,
-	} {
+	types := []ConditionType{t}
+	for _, cond := range r.dependents {
+		if cond == t {
+			types = append(types, r.happy)
+		}
+	}
+
+	for _, t := range types {
 		r.SetCondition(Condition{
-			Type:    t,
-			Status:  corev1.ConditionFalse,
-			Reason:  reason,
-			Message: fmt.Sprintf(messageFormat, messageA...),
+			Type:     t,
+			Status:   corev1.ConditionFalse,
+			Reason:   reason,
+			Message:  fmt.Sprintf(messageFormat, messageA...),
+			Severity: r.severity(t),
 		})
 	}
 }
@@ -295,8 +328,9 @@ func (r conditionsImpl) InitializeConditions() {
 func (r conditionsImpl) InitializeCondition(t ConditionType) {
 	if c := r.GetCondition(t); c == nil {
 		r.SetCondition(Condition{
-			Type:   t,
-			Status: corev1.ConditionUnknown,
+			Type:     t,
+			Status:   corev1.ConditionUnknown,
+			Severity: r.severity(t),
 		})
 	}
 }

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
@@ -42,6 +42,21 @@ const (
 	ConditionSucceeded ConditionType = "Succeeded"
 )
 
+// ConditionSeverity expresses the severity of a Condition Type failing.
+type ConditionSeverity string
+
+const (
+	// ConditionSeverityError specifies that a failure of a condition type
+	// should be viewed as an error.
+	ConditionSeverityError ConditionSeverity = "Error"
+	// ConditionSeverityWarning specifies that a failure of a condition type
+	// should be viewed as a warning, but that things could still work.
+	ConditionSeverityWarning ConditionSeverity = "Warning"
+	// ConditionSeverityInfo specifies that a failure of a condition type
+	// should be viewed as purely informational, and that things could still work.
+	ConditionSeverityInfo ConditionSeverity = "Info"
+)
+
 // Conditions defines a readiness condition for a Knative resource.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 // +k8s:deepcopy-gen=true
@@ -53,6 +68,11 @@ type Condition struct {
 	// Status of the condition, one of True, False, Unknown.
 	// +required
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
+
+	// Severity with which to treat failures of this type of condition.
+	// When this is not specified, it defaults to Error.
+	// +optional
+	Severity ConditionSeverity `json:"severity,omitempty" description:"how to interpret failures of this condition, one of Error, Warning, Info"`
 
 	// LastTransitionTime is the last time the condition transitioned from one status to another.
 	// We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
@@ -92,7 +112,6 @@ func (c *Condition) IsUnknown() bool {
 	}
 	return c.Status == corev1.ConditionUnknown
 }
-
 
 // Conditions is an Implementable "duck type".
 var _ duck.Implementable = (*Conditions)(nil)

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/generational_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/generational_types.go
@@ -27,7 +27,6 @@ import (
 // Generation is the schema for the generational portion of the payload
 type Generation int64
 
-
 // Generation is an Implementable "duck type".
 var _ duck.Implementable = (*Generation)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/legacy_targetable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/legacy_targetable_types.go
@@ -41,7 +41,6 @@ type LegacyTargetable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-
 // LegacyTargetable is an Implementable "duck type".
 var _ duck.Implementable = (*LegacyTargetable)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/retired_targetable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/retired_targetable_types.go
@@ -37,7 +37,6 @@ type Targetable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-
 // Targetable is an Implementable "duck type".
 var _ duck.Implementable = (*Targetable)(nil)
 

--- a/vendor/github.com/knative/pkg/controller/controller.go
+++ b/vendor/github.com/knative/pkg/controller/controller.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -136,12 +135,11 @@ func (c *Impl) EnqueueControllerOf(obj interface{}) {
 	}
 }
 
-// EnqueueLabelOf returns with an Enqueue func that takes a resource,
-// identifies its controller resource through given namespace and name labels,
-// converts it into a namespace/name string, and passes that to EnqueueKey.
-// Callers should pass in an empty string as namespace label key for obj
-// whose controller is of cluster-scoped resource.
-func (c *Impl) EnqueueLabelOf(namespaceLabel, nameLabel string) func(obj interface{}) {
+// EnqueueLabelOfNamespaceScopedResource returns with an Enqueue func that
+// takes a resource, identifies its controller resource through given namespace
+// and name labels, converts it into a namespace/name string, and passes that
+// to EnqueueKey. The controller resource must be of namespace-scoped.
+func (c *Impl) EnqueueLabelOfNamespaceScopedResource(namespaceLabel, nameLabel string) func(obj interface{}) {
 	return func(obj interface{}) {
 		object, err := kmeta.DeletionHandlingAccessor(obj)
 		if err != nil {
@@ -152,7 +150,7 @@ func (c *Impl) EnqueueLabelOf(namespaceLabel, nameLabel string) func(obj interfa
 		labels := object.GetLabels()
 		controllerKey, ok := labels[nameLabel]
 		if !ok {
-			c.logger.Infof("Object %s/%s does not have a referring name label %s",
+			c.logger.Debugf("Object %s/%s does not have a referring name label %s",
 				object.GetNamespace(), object.GetName(), nameLabel)
 			return
 		}
@@ -160,12 +158,40 @@ func (c *Impl) EnqueueLabelOf(namespaceLabel, nameLabel string) func(obj interfa
 		if namespaceLabel != "" {
 			controllerNamespace, ok := labels[namespaceLabel]
 			if !ok {
-				c.logger.Infof("Object %s/%s does not have a referring namespace label %s",
+				c.logger.Debugf("Object %s/%s does not have a referring namespace label %s",
 					object.GetNamespace(), object.GetName(), namespaceLabel)
 				return
 			}
 
-			controllerKey = fmt.Sprintf("%s/%s", controllerNamespace, controllerKey)
+			c.EnqueueKey(fmt.Sprintf("%s/%s", controllerNamespace, controllerKey))
+			return
+		}
+
+		// Pass through namespace of the object itself if no namespace label specified.
+		// This is for the scenario that object and the parent resource are of same namespace,
+		// e.g. to enqueue the revision of an endpoint.
+		c.EnqueueKey(fmt.Sprintf("%s/%s", object.GetNamespace(), controllerKey))
+	}
+}
+
+// EnqueueLabelOfClusterScopedResource returns with an Enqueue func
+// that takes a resource, identifies its controller resource through
+// given name label, and passes it to EnqueueKey.
+// The controller resource must be of cluster-scoped.
+func (c *Impl) EnqueueLabelOfClusterScopedResource(nameLabel string) func(obj interface{}) {
+	return func(obj interface{}) {
+		object, err := kmeta.DeletionHandlingAccessor(obj)
+		if err != nil {
+			c.logger.Error(err)
+			return
+		}
+
+		labels := object.GetLabels()
+		controllerKey, ok := labels[nameLabel]
+		if !ok {
+			c.logger.Debugf("Object %s/%s does not have a referring name label %s",
+				object.GetNamespace(), object.GetName(), nameLabel)
+			return
 		}
 
 		c.EnqueueKey(controllerKey)
@@ -188,10 +214,10 @@ func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) error {
 	logger := c.logger
 	logger.Info("Starting controller and workers")
 	for i := 0; i < threadiness; i++ {
-		go wait.Until(func() {
+		go func() {
 			for c.processNextWorkItem() {
 			}
-		}, time.Second, stopCh)
+		}()
 	}
 
 	logger.Info("Started workers")
@@ -208,74 +234,52 @@ func (c *Impl) processNextWorkItem() bool {
 	if shutdown {
 		return false
 	}
+	key := obj.(string)
 
-	// We wrap this block in a func so we can defer c.base.WorkQueue.Done.
-	err := func(obj interface{}) error {
-		startTime := time.Now()
-		// Send the metrics for the current queue depth
-		c.statsReporter.ReportQueueDepth(int64(c.WorkQueue.Len()))
+	startTime := time.Now()
+	// Send the metrics for the current queue depth
+	c.statsReporter.ReportQueueDepth(int64(c.WorkQueue.Len()))
 
-		// We call Done here so the workqueue knows we have finished
-		// processing this item. We also must remember to call Forget if we
-		// do not want this work item being re-queued. For example, we do
-		// not call Forget if a transient error occurs, instead the item is
-		// put back on the workqueue and attempted again after a back-off
-		// period.
-		defer c.WorkQueue.Done(obj)
+	// We call Done here so the workqueue knows we have finished
+	// processing this item. We also must remember to call Forget if
+	// reconcile succeeds. If a transient error occurs, we do not call
+	// Forget and put the item back to the queue with an increased
+	// delay.
+	defer c.WorkQueue.Done(key)
 
-		// We expect strings to come off the workqueue. These are of the
-		// form namespace/name. We do this as the delayed nature of the
-		// workqueue means the items in the informer cache may actually be
-		// more up to date that when the item was initially put onto the
-		// workqueue.
-		key, ok := obj.(string)
-		if !ok {
-			// As the item in the workqueue is actually invalid, we call
-			// Forget here else we'd go into a loop of attempting to
-			// process a work item that is invalid.
-			c.WorkQueue.Forget(obj)
-			c.logger.Errorf("expected string in workqueue but got %#v", obj)
-			c.statsReporter.ReportReconcile(time.Now().Sub(startTime), "[InvalidKeyType]", falseString)
-			return nil
+	var err error
+	defer func() {
+		status := trueString
+		if err != nil {
+			status = falseString
 		}
+		c.statsReporter.ReportReconcile(time.Now().Sub(startTime), key, status)
+	}()
 
-		var err error
-		defer func() {
-			status := trueString
-			if err != nil {
-				status = falseString
-			}
-			c.statsReporter.ReportReconcile(time.Now().Sub(startTime), key, status)
-		}()
+	// Embed the key into the logger and attach that to the context we pass
+	// to the Reconciler.
+	logger := c.logger.With(zap.String(logkey.Key, key))
+	ctx := logging.WithLogger(context.TODO(), logger)
 
-		// Embed the key into the logger and attach that to the context we pass
-		// to the Reconciler.
-		logger := c.logger.With(zap.String(logkey.Key, key))
-		ctx := logging.WithLogger(context.TODO(), logger)
-
-		// Run Reconcile, passing it the namespace/name string of the
-		// resource to be synced.
-		if err = c.Reconciler.Reconcile(ctx, key); err != nil {
-			c.handleErr(err, key)
-			return fmt.Errorf("error syncing %q: %v", key, err)
-		}
-
-		// Finally, if no error occurs we Forget this item so it does not
-		// get queued again until another change happens.
-		c.WorkQueue.Forget(obj)
-		c.logger.Infof("Successfully synced %q", key)
-		return nil
-	}(obj)
-
-	if err != nil {
-		c.logger.Error(zap.Error(err))
+	// Run Reconcile, passing it the namespace/name string of the
+	// resource to be synced.
+	if err = c.Reconciler.Reconcile(ctx, key); err != nil {
+		c.handleErr(err, key)
+		logger.Errorf("Reconcile failed. Time taken: %v.", time.Now().Sub(startTime))
 		return true
 	}
+
+	// Finally, if no error occurs we Forget this item so it does not
+	// have any delay when another change happens.
+	c.WorkQueue.Forget(key)
+	logger.Infof("Reconcile succeeded. Time taken: %v.", time.Now().Sub(startTime))
 
 	return true
 }
 
-func (c *Impl) handleErr(err error, key interface{}) {
+func (c *Impl) handleErr(err error, key string) {
+	c.logger.Error(zap.Error(err))
+
 	// Re-queue the key if it's an transient error.
 	if !IsPermanentError(err) {
 		c.WorkQueue.AddRateLimited(key)

--- a/vendor/github.com/knative/pkg/controller/stats_reporter.go
+++ b/vendor/github.com/knative/pkg/controller/stats_reporter.go
@@ -123,7 +123,7 @@ func (r *reporter) ReportReconcile(duration time.Duration, key, success string) 
 	}
 
 	stats.Record(ctx, reconcileCountStat.M(1))
-	stats.Record(ctx, reconcileLatencyStat.M(int64(duration)))
+	stats.Record(ctx, reconcileLatencyStat.M(int64(duration/time.Millisecond)))
 	return nil
 }
 

--- a/vendor/github.com/knative/pkg/test/zipkin/util.go
+++ b/vendor/github.com/knative/pkg/test/zipkin/util.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/knative/pkg/test/logging"
 	"go.opencensus.io/trace"
-	"k8s.io/client-go/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -68,7 +68,7 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 		return errors.New("No Zipkin Pod found on the cluster. Ensure monitoring is switched on for your Knative Setup")
 	}
 
-	portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace=" + ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
+	portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace="+ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
 	if err = portForwardCmd.Start(); err != nil {
 		return fmt.Errorf("Error starting kubectl port-forward command : %v", err)
 


### PR DESCRIPTION
This pr _attempts_ to fix #484

## Proposed Changes

*if a user tries to create a `Build` with a `BuildSpec` that has both `Template` and `Steps` return `ErrDisallowedFields(b.spec.steps)` because a `BuildTemplate` already includes `Steps` for the `Build` through its `BuildTemplateSpec`:

https://github.com/knative/build/blob/47e45d6af31266829e0eb362f0f250e70e041a63/pkg/apis/build/v1alpha1/build_template_types.go#L69

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
