### PR TITLE
Update vendored test-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -249,14 +249,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c30af6878fed9f93bc1ccb3a802720d1e5911c40d8903cd25fe95bcc21f0e31a"
+  digest = "1:952653aef2cb8b8a60637b1458591359e0dd0e89a816410dd175a76520796066"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "8a63be3b3795aa2f7ae9be32d840e096ba877c78"
+  revision = "fd150c6b0e760cfe85be17403e95e28fc6e38790"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -36,14 +36,17 @@ function build_resource_name() {
 }
 
 # Test cluster parameters
-readonly E2E_BASE_NAME=k$(basename ${REPO_ROOT_DIR})
+readonly E2E_BASE_NAME="k${REPO_NAME}"
 readonly E2E_CLUSTER_NAME=$(build_resource_name e2e-cls)
 readonly E2E_NETWORK_NAME=$(build_resource_name e2e-net)
 readonly E2E_CLUSTER_REGION=us-central1
-readonly E2E_CLUSTER_ZONE=${E2E_CLUSTER_REGION}-a
-readonly E2E_CLUSTER_NODES=3
 readonly E2E_CLUSTER_MACHINE=n1-standard-4
 readonly TEST_RESULT_FILE=/tmp/${E2E_BASE_NAME}-e2e-result
+# Each knative repository may have a different cluster size requirement here,
+# so we allow calling code to set these parameters.  If they are not set we
+# use some sane defaults.
+readonly E2E_MIN_CLUSTER_NODES=${E2E_MIN_CLUSTER_NODES:-1}
+readonly E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-3}
 
 # Flag whether test is using a boskos GCP project
 IS_BOSKOS=0
@@ -149,20 +152,21 @@ function create_test_cluster() {
   set -o pipefail
 
   header "Creating test cluster"
+
+  echo "Cluster will have a minimum of ${E2E_MIN_CLUSTER_NODES} and a maximum of ${E2E_MAX_CLUSTER_NODES} nodes."
+
   # Smallest cluster required to run the end-to-end-tests
   local CLUSTER_CREATION_ARGS=(
-    --gke-create-args="--enable-autoscaling --min-nodes=1 --max-nodes=${E2E_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate"
-    --gke-shape={\"default\":{\"Nodes\":${E2E_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
+    --gke-create-args="--enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate"
+    --gke-shape={\"default\":{\"Nodes\":${E2E_MIN_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
     --provider=gke
     --deployment=gke
     --cluster="${E2E_CLUSTER_NAME}"
-    --gcp-zone="${E2E_CLUSTER_ZONE}"
+    --gcp-region="${E2E_CLUSTER_REGION}"
     --gcp-network="${E2E_NETWORK_NAME}"
     --gke-environment=prod
   )
-  if (( IS_BOSKOS )); then
-    CLUSTER_CREATION_ARGS+=(--gcp-service-account=/etc/service-account/service-account.json)
-  else
+  if (( ! IS_BOSKOS )); then
     CLUSTER_CREATION_ARGS+=(--gcp-project=${GCP_PROJECT})
   fi
   # SSH keys are not used, but kubetest checks for their existence.
@@ -241,7 +245,7 @@ function setup_test_cluster() {
   if [[ -z ${K8S_CLUSTER_OVERRIDE} ]]; then
     USING_EXISTING_CLUSTER=0
     export K8S_CLUSTER_OVERRIDE=$(kubectl config current-context)
-    acquire_cluster_admin_role ${K8S_USER_OVERRIDE} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_ZONE}
+    acquire_cluster_admin_role ${K8S_USER_OVERRIDE} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION}
     # Make sure we're in the default namespace. Currently kubetest switches to
     # test-pods namespace when creating the cluster.
     kubectl config set-context $K8S_CLUSTER_OVERRIDE --namespace=default
@@ -257,6 +261,7 @@ function setup_test_cluster() {
   echo "- Docker is ${DOCKER_REPO_OVERRIDE}"
 
   export KO_DOCKER_REPO="${DOCKER_REPO_OVERRIDE}"
+  export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"
 
   trap teardown_test_resources EXIT
 
@@ -293,11 +298,6 @@ USING_EXISTING_CLUSTER=1
 GCP_PROJECT=""
 E2E_SCRIPT=""
 E2E_CLUSTER_VERSION=""
-
-function abort() {
-  echo "error: $@"
-  exit 1
-}
 
 # Parse flags and initialize the test cluster.
 function initialize() {
@@ -357,10 +357,8 @@ function initialize() {
   (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
 
   # Safety checks
-
-  if [[ "${DOCKER_REPO_OVERRIDE}" =~ ^gcr.io/knative-(releases|nightly)/?$ ]]; then
-    abort "\$DOCKER_REPO_OVERRIDE is set to ${DOCKER_REPO_OVERRIDE}, which is forbidden"
-  fi
+  is_protected_gcr ${DOCKER_REPO_OVERRIDE} && \
+    abort "\$DOCKER_REPO_OVERRIDE set to ${DOCKER_REPO_OVERRIDE}, which is forbidden"
 
   readonly RUN_TESTS
   readonly EMIT_METRICS

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -48,11 +48,6 @@ function exit_if_presubmit_not_required() {
   fi
 }
 
-function abort() {
-  echo "error: $@"
-  exit 1
-}
-
 # Process flags and run tests accordingly.
 function main() {
   exit_if_presubmit_not_required
@@ -70,6 +65,12 @@ function main() {
     go version
     echo ">> git version"
     git version
+    echo ">> bazel version"
+    bazel version 2> /dev/null
+    if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+      echo ">> docker version"
+      docker version
+    fi
   fi
 
   [[ -z $1 ]] && set -- "--all-tests"

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -19,6 +19,9 @@
 
 source $(dirname ${BASH_SOURCE})/library.sh
 
+# Github upstream.
+readonly KNATIVE_UPSTREAM="github.com/knative/${REPO_NAME}"
+
 # Simple banner for logging purposes.
 # Parameters: $1 - message to display.
 function banner() {
@@ -35,6 +38,11 @@ function tag_images_in_yaml() {
   echo "Tagging images under '${DOCKER_BASE}' with ${TAG}"
   for image in $(grep -o "${DOCKER_BASE}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
     gcloud -q container images add-tag ${image} ${image%%@*}:${TAG}
+
+    # Georeplicate to {us,eu,asia}.gcr.io
+    gcloud -q container images add-tag ${image} us.${image%%@*}:${TAG}
+    gcloud -q container images add-tag ${image} eu.${image%%@*}:${TAG}
+    gcloud -q container images add-tag ${image} asia.${image%%@*}:${TAG}
   done
 }
 
@@ -43,7 +51,7 @@ function tag_images_in_yaml() {
 # Parameters: $1 - yaml file to copy.
 function publish_yaml() {
   function verbose_gsutil_cp {
-    local DEST=gs://${RELEASE_GCS_BUCKET}/$2/
+    local DEST="gs://${RELEASE_GCS_BUCKET}/$2/"
     echo "Publishing $1 to ${DEST}"
     gsutil cp $1 ${DEST}
   }
@@ -65,10 +73,90 @@ RELEASE_BRANCH=""
 RELEASE_GCS_BUCKET=""
 KO_FLAGS=""
 export KO_DOCKER_REPO=""
+export GITHUB_TOKEN=""
 
-function abort() {
-  echo "error: $@"
-  exit 1
+# Convenience function to run the hub tool.
+# Parameters: $1..$n - arguments to hub.
+function hub_tool() {
+  run_go_tool github.com/github/hub hub $@
+}
+
+# Return the master version of a release.
+# For example, "v0.2.1" returns "0.2"
+# Parameters: $1 - release version label.
+function master_version() {
+  local release="${1//v/}"
+  local tokens=(${release//\./ })
+  echo "${tokens[0]}.${tokens[1]}"
+}
+
+# Return the release build number of a release.
+# For example, "v0.2.1" returns "1".
+# Parameters: $1 - release version label.
+function release_build_number() {
+  local tokens=(${1//\./ })
+  echo "${tokens[2]}"
+}
+
+# Setup the repository upstream, if not set.
+function setup_upstream() {
+  # hub and checkout need the upstream URL to be set
+  # TODO(adrcunha): Use "git remote get-url" once available on Prow.
+  local upstream="$(git config --get remote.upstream.url)"
+  echo "Remote upstream URL is '${upstream}'"
+  if [[ -z "${upstream}" ]]; then
+    upstream="https://${KNATIVE_UPSTREAM}"
+    echo "Setting remote upstream URL to '${upstream}'"
+    git remote add upstream ${upstream}
+  fi
+  git fetch --all
+}
+
+# Setup version, branch and release notes for a "dot" release.
+function prepare_dot_release() {
+  echo "Dot release requested"
+  TAG_RELEASE=1
+  PUBLISH_RELEASE=1
+  # List latest release
+  local releases # don't combine with the line below, or $? will be 0
+  releases="$(hub_tool release)"
+  [[ $? -eq 0 ]] || abort "cannot list releases"
+  # If --release-branch passed, restrict to that release
+  if [[ -n "${RELEASE_BRANCH}" ]]; then
+    local version_filter="v${RELEASE_BRANCH##release-}"
+    echo "Dot release will be generated for ${version_filter}"
+    releases="$(echo "${releases}" | grep ^${version_filter})"
+  fi
+  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r | head -1)"
+  [[ -n "${last_version}" ]] || abort "no previous release exist"
+  if [[ -z "${RELEASE_BRANCH}" ]]; then
+    echo "Last release is ${last_version}"
+    # Determine branch
+    local major_minor_version="$(master_version ${last_version})"
+    RELEASE_BRANCH="release-${major_minor_version}"
+    echo "Last release branch is ${RELEASE_BRANCH}"
+  fi
+  # Ensure there are new commits in the branch, otherwise we don't create a new release
+  local last_release_commit="$(git rev-list -n 1 ${last_version})"
+  local release_branch_commit="$(git rev-list -n 1 upstream/${RELEASE_BRANCH})"
+  [[ -n "${last_release_commit}" ]] || abort "cannot get last release commit"
+  [[ -n "${release_branch_commit}" ]] || abort "cannot get release branch last commit"
+  if [[ "${last_release_commit}" == "${release_branch_commit}" ]]; then
+    echo "*** Branch ${RELEASE_BRANCH} is at commit ${release_branch_commit}"
+    echo "*** Branch ${RELEASE_BRANCH} has no new cherry-picks since release ${last_version}"
+    echo "*** No dot release will be generated, as no changes exist"
+    exit 0
+  fi
+  # Create new release version number
+  local last_build="$(release_build_number ${last_version})"
+  RELEASE_VERSION="${major_minor_version}.$(( last_build + 1 ))"
+  echo "Will create release ${RELEASE_VERSION} at commit ${release_branch_commit}"
+  # If --release-notes not used, copy from the latest release
+  if [[ -z "${RELEASE_NOTES}" ]]; then
+    RELEASE_NOTES="$(mktemp)"
+    hub_tool release show -f "%b" ${last_version} > ${RELEASE_NOTES}
+    echo "Release notes from ${last_version} copied to ${RELEASE_NOTES}"
+  fi
 }
 
 # Parses flags and sets environment variables accordingly.
@@ -79,53 +167,62 @@ function parse_flags() {
   RELEASE_BRANCH=""
   KO_FLAGS="-P"
   KO_DOCKER_REPO="gcr.io/knative-nightly"
-  RELEASE_GCS_BUCKET="knative-nightly/$(basename ${REPO_ROOT_DIR})"
+  RELEASE_GCS_BUCKET="knative-nightly/${REPO_NAME}"
+  GITHUB_TOKEN=""
   local has_gcr_flag=0
   local has_gcs_flag=0
+  local is_dot_release=0
 
   cd ${REPO_ROOT_DIR}
   while [[ $# -ne 0 ]]; do
     local parameter=$1
-    case $parameter in
+    case ${parameter} in
       --skip-tests) SKIP_TESTS=1 ;;
       --tag-release) TAG_RELEASE=1 ;;
       --notag-release) TAG_RELEASE=0 ;;
       --publish) PUBLISH_RELEASE=1 ;;
       --nopublish) PUBLISH_RELEASE=0 ;;
-      --release-gcr)
+      --dot-release) is_dot_release=1 ;;
+      *)
+        [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift
-        [[ $# -ge 1 ]] || abort "missing GCR after --release-gcr"
-        KO_DOCKER_REPO=$1
-        has_gcr_flag=1
-        ;;
-      --release-gcs)
-        shift
-        [[ $# -ge 1 ]] || abort "missing GCS bucket after --release-gcs"
-        RELEASE_GCS_BUCKET=$1
-        has_gcs_flag=1
-        ;;
-      --version)
-        shift
-        [[ $# -ge 1 ]] || abort "missing version after --version"
-        [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || abort "version format must be '[0-9].[0-9].[0-9]'"
-        RELEASE_VERSION=$1
-        ;;
-      --branch)
-        shift
-        [[ $# -ge 1 ]] || abort "missing branch after --commit"
-        [[ $1 =~ ^release-[0-9]+\.[0-9]+$ ]] || abort "branch name must be 'release-[0-9].[0-9]'"
-        RELEASE_BRANCH=$1
-        ;;
-      --release-notes)
-        shift
-        [[ $# -ge 1 ]] || abort "missing release notes file after --release-notes"
-        [[ ! -f "$1" ]] && abort "file $1 doesn't exist"
-        RELEASE_NOTES=$1
-        ;;
-      *) abort "unknown option ${parameter}" ;;
+        case ${parameter} in
+          --github-token)
+            [[ ! -f "$1" ]] && abort "file $1 doesn't exist"
+            GITHUB_TOKEN="$(cat $1)"
+            [[ -n "${GITHUB_TOKEN}" ]] || abort "file $1 is empty"
+            ;;
+          --release-gcr)
+            KO_DOCKER_REPO=$1
+            has_gcr_flag=1
+            ;;
+          --release-gcs)
+            RELEASE_GCS_BUCKET=$1
+            has_gcs_flag=1
+            ;;
+          --version)
+            [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || abort "version format must be '[0-9].[0-9].[0-9]'"
+            RELEASE_VERSION=$1
+            ;;
+          --branch)
+            [[ $1 =~ ^release-[0-9]+\.[0-9]+$ ]] || abort "branch name must be 'release-[0-9].[0-9]'"
+            RELEASE_BRANCH=$1
+            ;;
+          --release-notes)
+            [[ ! -f "$1" ]] && abort "file $1 doesn't exist"
+            RELEASE_NOTES=$1
+            ;;
+          *) abort "unknown option ${parameter}" ;;
+        esac
     esac
     shift
   done
+
+  # Setup dot releases
+  if (( is_dot_release )); then
+    setup_upstream
+    prepare_dot_release
+  fi
 
   # Update KO_DOCKER_REPO and KO_FLAGS if we're not publishing.
   if (( ! PUBLISH_RELEASE )); then
@@ -178,7 +275,6 @@ function run_validation_tests() {
 # Initialize everything (flags, workspace, etc) for a release.
 function initialize() {
   parse_flags $@
-
   # Log what will be done and where.
   banner "Release configuration"
   echo "- Destination GCR: ${KO_DOCKER_REPO}"
@@ -200,6 +296,7 @@ function initialize() {
 
   # Checkout specific branch, if necessary
   if (( BRANCH_RELEASE )); then
+    setup_upstream
     git checkout upstream/${RELEASE_BRANCH} || abort "cannot checkout branch ${RELEASE_BRANCH}"
   fi
 }
@@ -223,8 +320,11 @@ function branch_release() {
     cat ${RELEASE_NOTES} >> ${description}
   fi
   git tag -a ${TAG} -m "${title}"
-  git push $(git remote get-url upstream) tag ${TAG}
-  run_go_tool github.com/github/hub hub release create \
+  local repo_url="${KNATIVE_UPSTREAM}"
+  [[ -n "${GITHUB_TOKEN}}" ]] && repo_url="${GITHUB_TOKEN}@${repo_url}"
+  hub_tool push https://${repo_url} tag ${TAG}
+
+  hub_tool release create \
       --prerelease \
       ${attachments[@]} \
       --file=${description} \


### PR DESCRIPTION
Major changes:
* Use regional clusters for E2E tests
* Allow specifying the E2E test cluster min/max size using environment variables
* Use the already setup service account when running E2E tests
* Block tests using the release/nightly GCRs
* Remove all code deleting images from GCR
* Use go-junit-report for go test summaries (bye bazel)
* Georeplicate GCR releases
* Add support to weekly "dot" releases

Fixes #511.