### PR TITLE
support alternate git ssh ports

### DIFF
--- a/pkg/credentials/gitcreds/ssh.go
+++ b/pkg/credentials/gitcreds/ssh.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -85,8 +86,15 @@ func (dc *sshGitConfig) Write() error {
 	//  2. Compute its part of "~/.ssh/config"
 	//  3. Compute its part of "~/.ssh/known_hosts"
 	var configEntries []string
+	var defaultPort = "22"
 	var knownHosts []string
 	for _, k := range dc.order {
+		var host, port string
+		var err error
+		if host, port, err = net.SplitHostPort(k); err != nil {
+			host = k
+			port = defaultPort
+		}
 		v := dc.entries[k]
 		if err := v.Write(sshDir); err != nil {
 			return err
@@ -94,7 +102,8 @@ func (dc *sshGitConfig) Write() error {
 		configEntries = append(configEntries, fmt.Sprintf(`Host %s
     HostName %s
     IdentityFile %s
-`, k, k, v.path(sshDir)))
+    Port %s
+`, host, host, v.path(sshDir), port))
 
 		knownHosts = append(knownHosts, v.knownHosts)
 	}


### PR DESCRIPTION
Fixes #

## Proposed Changes

* git creds only supports the default port, 22
* use the net library to split the host and port, appending default if necessary

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
