### PR TITLE
Add PodSecurityPolicy

### DIFF
--- a/config/101-podsecuritypolicy.yaml
+++ b/config/101-podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: knative-build
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+  - 'configMap'
+  - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -21,3 +21,7 @@ rules:
   - apiGroups: ["caching.internal.knative.dev"]
     resources: ["images"]
     verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["knative-build"]
+    verbs: ["use"]


### PR DESCRIPTION
Fixes https://github.com/knative/build/issues/509

## Proposed Changes

* Adds PodSecurityPolicy to be used by `knative-build` components.

Unfortunately, we have to allow `build-webhook` to run as root (see `runAsUser.rule: 'RunAsAny'` below), since it serves on `443`. Ideally we'd whitelist `CAP_NET_BIND_SERVICE` and not run as root, but the `capabilities` option for PodSecurityPolicies does not work as expected: https://github.com/kubernetes/kubernetes/issues/56374.

