### PR TITLE
Allow PersistentVolumeClaims to be parameterized

### DIFF
--- a/pkg/reconciler/build/apply.go
+++ b/pkg/reconciler/build/apply.go
@@ -87,6 +87,14 @@ func ApplyReplacements(build *v1alpha1.Build, replacements map[string]string) *v
 		}
 	}
 
+	// Apply variable expansion to the build's volumes
+	for i, v := range build.Spec.Volumes {
+		build.Spec.Volumes[i].Name = applyReplacements(v.Name)
+		if c := v.PersistentVolumeClaim; c != nil {
+			c.ClaimName = applyReplacements(c.ClaimName)
+		}
+	}
+
 	if buildTmpl := build.Spec.Template; buildTmpl != nil && len(buildTmpl.Env) > 0 {
 		// Apply variable expansion to the build's overridden
 		// environment variables

--- a/pkg/reconciler/build/apply_test.go
+++ b/pkg/reconciler/build/apply_test.go
@@ -115,6 +115,14 @@ func TestApplyTemplate(t *testing.T) {
 				Parameters: []v1alpha1.ParameterSpec{{
 					Name: "FOO",
 				}},
+				Volumes: []corev1.Volume{{
+					Name: "${FOO}",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "${FOO}",
+						},
+					},
+				}},
 			},
 		},
 		want: &v1alpha1.Build{
@@ -141,6 +149,14 @@ func TestApplyTemplate(t *testing.T) {
 						Value: "world",
 					}},
 				},
+				Volumes: []corev1.Volume{{
+					Name: "world",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "world",
+						},
+					},
+				}},
 			},
 		},
 	}, {


### PR DESCRIPTION
## Proposed Changes

now parameterized:
- `$.spec.volumes[]name`
- `$.spec.volumes[]persistentVolumeClaim.claimName`

```yaml
apiVersion: build.knative.dev/v1alpha1
kind: BuildTemplate
spec:
  parameters:
    - name: VOLUME_MOUNT
      description: Name of volume to mount in the build pod.
      default: cache
    - name: BUILD_CACHE
      description: Name of PersistentVolumeClaim to use as a cache for this build.
  steps: []
  volumes:
    - name: ${VOLUME_MOUNT} # now parameterized
      persistentVolumeClaim:
        claimName: ${BUILD_CACHE} # now parameterized
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
BuildTemplates can now have parameterized volume name and persistent
volume claimName.
```

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->