### PR TITLE
Align release filename with serving repo.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -17,7 +17,7 @@
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 
 # Local generated yaml file
-readonly OUTPUT_YAML=release.yaml
+readonly OUTPUT_YAML=build.yaml
 
 # Script entry point
 


### PR DESCRIPTION
Fixes #468 

## Proposed Changes

* Renames `release.yaml` to `build.yaml`

**Release Note**

```release-note
Renamed release.yaml to build.yaml
```

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
