### PR TITLE
creds-init: add support for kubernetes.io/dockerconfigjson

### DIFF
--- a/pkg/credentials/dockercreds/creds.go
+++ b/pkg/credentials/dockercreds/creds.go
@@ -33,11 +33,13 @@ import (
 
 const annotationPrefix = "build.knative.dev/docker-"
 
-var config dockerConfig
+var config basicDocker
+var dockerConfig string
 
 func flags(fs *flag.FlagSet) {
-	config = dockerConfig{make(map[string]entry)}
+	config = basicDocker{make(map[string]entry)}
 	fs.Var(&config, "basic-docker", "List of secret=url pairs.")
+	fs.StringVar(&dockerConfig, "docker-config", "", "Config.json secret file.")
 }
 
 func init() {
@@ -45,12 +47,12 @@ func init() {
 }
 
 // As the flag is read, this status is populated.
-// dockerConfig implements flag.Value
-type dockerConfig struct {
+// basicDocker implements flag.Value
+type basicDocker struct {
 	Entries map[string]entry `json:"auths"`
 }
 
-func (dc *dockerConfig) String() string {
+func (dc *basicDocker) String() string {
 	if dc == nil {
 		// According to flag.Value this can happen.
 		return ""
@@ -62,7 +64,7 @@ func (dc *dockerConfig) String() string {
 	return strings.Join(urls, ",")
 }
 
-func (dc *dockerConfig) Set(value string) error {
+func (dc *basicDocker) Set(value string) error {
 	parts := strings.Split(value, "=")
 	if len(parts) != 2 {
 		return fmt.Errorf("Expect entries of the form secret=url, got: %v", value)
@@ -82,12 +84,16 @@ func (dc *dockerConfig) Set(value string) error {
 	return nil
 }
 
+type configFile struct {
+	Auth map[string]entry `json:"auths"`
+}
+
 type entry struct {
 	Secret   string `json:"-"`
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
 	Auth     string `json:"auth"`
-	Email    string `json:"email"`
+	Email    string `json:"email,omitempty"`
 }
 
 func newEntry(secret string) (*entry, error) {
@@ -114,39 +120,68 @@ func newEntry(secret string) (*entry, error) {
 	}, nil
 }
 
-type dockerConfigBuilder struct{}
+type basicDockerBuilder struct{}
 
 // NewBuilder returns a new builder for Docker credentials.
-func NewBuilder() credentials.Builder { return &dockerConfigBuilder{} }
+func NewBuilder() credentials.Builder { return &basicDockerBuilder{} }
 
 // MatchingAnnotations extracts flags for the credential helper
 // from the supplied secret and returns a slice (of length 0 or
 // greater) of applicable domains.
-func (*dockerConfigBuilder) MatchingAnnotations(secret *corev1.Secret) []string {
+func (*basicDockerBuilder) MatchingAnnotations(secret *corev1.Secret) []string {
 	var flags []string
 	switch secret.Type {
 	case corev1.SecretTypeBasicAuth:
-		// OK.
+		for _, v := range credentials.SortAnnotations(secret.Annotations, annotationPrefix) {
+			flags = append(flags, fmt.Sprintf("-basic-docker=%s=%s", secret.Name, v))
+		}
+	case corev1.SecretTypeDockerConfigJson:
+		flags = append(flags, fmt.Sprintf("-docker-config=%s", secret.Name))
 	default:
 		return flags
 	}
 
-	for _, v := range credentials.SortAnnotations(secret.Annotations, annotationPrefix) {
-		flags = append(flags, fmt.Sprintf("-basic-docker=%s=%s", secret.Name, v))
-	}
 	return flags
 }
 
-func (*dockerConfigBuilder) Write() error {
+func (*basicDockerBuilder) Write() error {
 	dockerDir := filepath.Join(os.Getenv("HOME"), ".docker")
-	dockerConfig := filepath.Join(dockerDir, "config.json")
+	basicDocker := filepath.Join(dockerDir, "config.json")
 	if err := os.MkdirAll(dockerDir, os.ModePerm); err != nil {
 		return err
 	}
 
-	content, err := json.Marshal(config)
+	cf := configFile{Auth: config.Entries}
+	if dockerConfig != "" {
+		dockerConfigAuthMap, err := authsFromDockerConfig(dockerConfig)
+		if err != nil {
+			return err
+		}
+		for k, v := range config.Entries {
+			dockerConfigAuthMap[k] = v
+		}
+		cf.Auth = dockerConfigAuthMap
+	}
+	content, err := json.Marshal(cf)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dockerConfig, content, 0600)
+	return ioutil.WriteFile(basicDocker, content, 0600)
+}
+
+func authsFromDockerConfig(secret string) (map[string]entry, error) {
+	secretPath := credentials.VolumeName(secret)
+	m := make(map[string]entry)
+	c := configFile{}
+	data, err := ioutil.ReadFile(filepath.Join(secretPath, corev1.DockerConfigJsonKey))
+	if err != nil {
+		return m, err
+	}
+	if err := json.Unmarshal(data, &c); err != nil {
+		return m, err
+	}
+	for k, v := range c.Auth {
+		m[k] = v
+	}
+	return m, nil
 }

--- a/pkg/credentials/dockercreds/creds_test.go
+++ b/pkg/credentials/dockercreds/creds_test.go
@@ -125,7 +125,7 @@ func TestFlagHandlingMissingFiles(t *testing.T) {
 	}
 	// No username / password files yields an error.
 
-	cfg := dockerConfig{make(map[string]entry)}
+	cfg := basicDocker{make(map[string]entry)}
 	if err := cfg.Set("not-found=https://us.gcr.io"); err == nil {
 		t.Error("Set(); got success, wanted error.")
 	}
@@ -144,7 +144,7 @@ func TestFlagHandlingURLCollision(t *testing.T) {
 		t.Fatalf("ioutil.WriteFile(password) = %v", err)
 	}
 
-	cfg := dockerConfig{make(map[string]entry)}
+	cfg := basicDocker{make(map[string]entry)}
 	if err := cfg.Set("foo=https://us.gcr.io"); err != nil {
 		t.Fatalf("First Set() = %v", err)
 	}
@@ -154,14 +154,14 @@ func TestFlagHandlingURLCollision(t *testing.T) {
 }
 
 func TestMalformedValueTooMany(t *testing.T) {
-	cfg := dockerConfig{make(map[string]entry)}
+	cfg := basicDocker{make(map[string]entry)}
 	if err := cfg.Set("bar=baz=blah"); err == nil {
 		t.Error("Second Set(); got success, wanted error.")
 	}
 }
 
 func TestMalformedValueTooFew(t *testing.T) {
-	cfg := dockerConfig{make(map[string]entry)}
+	cfg := basicDocker{make(map[string]entry)}
 	if err := cfg.Set("bar"); err == nil {
 		t.Error("Second Set(); got success, wanted error.")
 	}
@@ -217,5 +217,53 @@ func TestMatchingAnnotations(t *testing.T) {
 		if !cmp.Equal(ts.wantFlag, gotFlag) {
 			t.Errorf("MatchingAnnotations() Mismatch of flags; wanted: %v got: %v ", ts.wantFlag, gotFlag)
 		}
+	}
+}
+
+func TestMultipleFlagHandling(t *testing.T) {
+	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	fooDir := credentials.VolumeName("foo")
+	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
+		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(fooDir, corev1.BasicAuthUsernameKey), []byte("bar"), 0777); err != nil {
+		t.Fatalf("ioutil.WriteFile(username) = %v", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(fooDir, corev1.BasicAuthPasswordKey), []byte("baz"), 0777); err != nil {
+		t.Fatalf("ioutil.WriteFile(password) = %v", err)
+	}
+
+	barDir := credentials.VolumeName("bar")
+	if err := os.MkdirAll(barDir, os.ModePerm); err != nil {
+		t.Fatalf("os.MkdirAll(%s) = %v", barDir, err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(barDir, corev1.DockerConfigJsonKey), []byte(`{"auths":{"https://index.docker.io/v1":{"auth":"fooisbar"}}}`), 0777); err != nil {
+		t.Fatalf("ioutil.WriteFile(username) = %v", err)
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	flags(fs)
+	err := fs.Parse([]string{
+		"-basic-docker=foo=https://us.gcr.io",
+		"-docker-config=bar",
+	})
+	if err != nil {
+		t.Fatalf("flag.CommandLine.Parse() = %v", err)
+	}
+
+	os.Setenv("HOME", credentials.VolumePath)
+	if err := NewBuilder().Write(); err != nil {
+		t.Fatalf("Write() = %v", err)
+	}
+
+	b, err := ioutil.ReadFile(filepath.Join(credentials.VolumePath, ".docker", "config.json"))
+	if err != nil {
+		t.Fatalf("ioutil.ReadFile(.docker/config.json) = %v", err)
+	}
+
+	// Note: "auth" is base64(username + ":" + password)
+	expected := `{"auths":{"https://index.docker.io/v1":{"auth":"fooisbar"},"https://us.gcr.io":{"username":"bar","password":"baz","auth":"YmFyOmJheg==","email":"not@val.id"}}}`
+	if string(b) != expected {
+		t.Errorf("got: %v, wanted: %v", string(b), expected)
 	}
 }


### PR DESCRIPTION
- Merge knative flavored `kubernetes.io/basic-auth` creds with
  `kubernetes.io/dockerconfigjson` ones
- knative flavored creds takes precedences over the `dockerconfigjson` one's

Fixes #389 

/cc @ImJasonH @mattmoor @AkihiroSuda

PS: porting this to `knative/build-pipeline` too :angel: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
