### PR TITLE
Resync every 10h instead of every 30s

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -44,6 +44,7 @@ import (
 const (
 	threadsPerController = 2
 	logLevelKey          = "controller"
+	resyncPeriod         = 10 * time.Hour
 )
 
 var (
@@ -90,9 +91,9 @@ func main() {
 		logger.Fatalf("Error building Caching clientset: %v", err)
 	}
 
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
-	buildInformerFactory := informers.NewSharedInformerFactory(buildClient, time.Second*30)
-	cachingInformerFactory := cachinginformers.NewSharedInformerFactory(cachingClient, time.Second*30)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, resyncPeriod)
+	buildInformerFactory := informers.NewSharedInformerFactory(buildClient, resyncPeriod)
+	cachingInformerFactory := cachinginformers.NewSharedInformerFactory(cachingClient, resyncPeriod)
 
 	buildInformer := buildInformerFactory.Build().V1alpha1().Builds()
 	buildTemplateInformer := buildInformerFactory.Build().V1alpha1().BuildTemplates()


### PR DESCRIPTION
Fixes #541

## Proposed Changes

* Resync our custom resources every 10 hours, and rely on build/pod watch updates to trigger syncs in most cases

Resyncing every 30s seems to lead us to hit rate limits that we never recover from when there are too many builds in the system at a given time. Serving also switched to resyncing every 10h for similar scaling reasons.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->