### PR TITLE
Allow templating for Volumes of type secret

### DIFF
--- a/pkg/reconciler/build/apply.go
+++ b/pkg/reconciler/build/apply.go
@@ -146,4 +146,8 @@ func applyVolumeReplacements(volume *corev1.Volume, applyReplacements func(strin
 	if volume.VolumeSource.ConfigMap != nil {
 		volume.ConfigMap.Name = applyReplacements(volume.ConfigMap.Name)
 	}
+
+	if volume.VolumeSource.Secret != nil {
+		volume.Secret.SecretName = applyReplacements(volume.Secret.SecretName)
+	}
 }

--- a/pkg/reconciler/build/apply_test.go
+++ b/pkg/reconciler/build/apply_test.go
@@ -775,6 +775,45 @@ func TestApplyReplacements(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "replacement in volumes (secret) ",
+			args: args{
+				build: &v1alpha1.Build{
+					Spec: v1alpha1.BuildSpec{
+						Volumes: []corev1.Volume{{
+							Name: "${name}",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									"${secretname}",
+									nil,
+									nil,
+									nil,
+								},
+							}},
+						},
+					},
+				},
+				replacements: map[string]string{
+					"name":       "mysecret",
+					"secretname": "totallysecure",
+				},
+			},
+			want: &v1alpha1.Build{
+				Spec: v1alpha1.BuildSpec{
+					Volumes: []corev1.Volume{{
+						Name: "mysecret",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								"totallysecure",
+								nil,
+								nil,
+								nil,
+							},
+						}},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -364,6 +364,12 @@ func TestPodAffinity(t *testing.T) {
 func TestPersistentVolumeClaim(t *testing.T) {
 	buildTestNamespace, logger, clients := initialize("TestPersistentVolumeClaim")
 
+	buildName := "persistent-volume-claim"
+
+	test.CleanupOnInterrupt(func() { teardownBuild(clients, logger, buildTestNamespace, buildName) }, logger)
+	defer teardownBuild(clients, logger, buildTestNamespace, buildName)
+	defer teardownNamespace(clients, buildTestNamespace, logger)
+
 	// First, create the PVC.
 	if _, err := clients.kubeClient.Kube.CoreV1().PersistentVolumeClaims(buildTestNamespace).Create(&corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -569,7 +575,6 @@ func TestSimpleBuildWithHybridSources(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Error creating build: %v", err)
 	}
-
 	if _, err := clients.buildClient.watchBuild(buildName); err != nil {
 		t.Fatalf("Error watching build: %v", err)
 	}

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -575,6 +575,7 @@ func TestSimpleBuildWithHybridSources(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Error creating build: %v", err)
 	}
+
 	if _, err := clients.buildClient.watchBuild(buildName); err != nil {
 		t.Fatalf("Error watching build: %v", err)
 	}


### PR DESCRIPTION
## Proposed Changes

* This change allows to use templating for volumes of type Secret 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
BuildTemplate now supports the replacement of secret names with parameters
```

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
