### PR TITLE
Fix release script

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -250,14 +250,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:adce1d5f23880effb73db34201248efb0e997e2e0fbc24e3e32b8afc2612c5df"
+  digest = "1:53602e9bf19c125850e5a142718331602779c9304b9815e72d3d3061023245a9"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "353f1d711050b43ac4137791c1ac10b96927d949"
+  revision = "425d36b7c2477efe7c8981dbdf76d2eb10c1d4e1"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -19,56 +19,19 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 # Local generated yaml file
 readonly OUTPUT_YAML=build.yaml
 
-# Script entry point
+function build_release() {
+  # When building a versioned release, we must use .ko.yaml.release
+  if (( PUBLISH_TO_GITHUB )); then
+    # KO_CONFIG_PATH expects a path containing a .ko.yaml file
+    export KO_CONFIG_PATH="$(mktemp -d)"
+    cp .ko.yaml.release "${KO_CONFIG_PATH}/.ko.yaml"
+    echo "Using .ko.yaml.release for base image overrides"
+  fi
+  # Build the base image for creds-init and git images.
+  docker build -t "${KO_DOCKER_REPO}/github.com/knative/build/build-base" -f images/Dockerfile images/
+  echo "Building build-crd"
+  ko resolve ${KO_FLAGS} -f config/ > ${OUTPUT_YAML}
+  YAMLS_TO_PUBLISH="${OUTPUT_YAML}"
+}
 
-initialize $@
-
-set -o errexit
-set -o pipefail
-
-# When building a versioned release, we must use .ko.yaml.release
-if (( BRANCH_RELEASE )); then
-  # KO_CONFIG_PATH expects a path containing a .ko.yaml file
-  export KO_CONFIG_PATH="$(mktemp -d)"
-  cp .ko.yaml.release "${KO_CONFIG_PATH}/.ko.yaml"
-  echo "- Using .ko.yaml.release for base image overrides"
-fi
-
-run_validation_tests ./test/presubmit-tests.sh
-
-# Build the release
-
-banner "Building the release"
-
-# Location of the base image for creds-init and git images
-readonly BUILD_BASE_GCR="${KO_DOCKER_REPO}/github.com/knative/build/build-base"
-
-# Build should not try to deploy anything, use a bogus value for cluster.
-export K8S_CLUSTER_OVERRIDE=CLUSTER_NOT_SET
-export K8S_USER_OVERRIDE=USER_NOT_SET
-export DOCKER_REPO_OVERRIDE=DOCKER_NOT_SET
-
-# Build the base image for creds-init and git images.
-docker build -t ${BUILD_BASE_GCR} -f images/Dockerfile images/
-
-echo "Building build-crd"
-ko resolve ${KO_FLAGS} -f config/ > ${OUTPUT_YAML}
-tag_images_in_yaml ${OUTPUT_YAML}
-
-echo "New release built successfully"
-
-if (( ! PUBLISH_RELEASE )); then
- exit 0
-fi
-
-# Push the base image for creds-init and git images.
-echo "Pushing base images to ${BUILD_BASE_GCR}"
-docker push ${BUILD_BASE_GCR}
-
-publish_yaml ${OUTPUT_YAML}
-
-branch_release "Knative Build" "${OUTPUT_YAML}"
-
-echo "New release published successfully"
-
-# TODO(mattmoor): Create other aliases?
+main $@

--- a/test/e2e-tests-yaml.sh
+++ b/test/e2e-tests-yaml.sh
@@ -23,10 +23,6 @@ source $(dirname $0)/e2e-common.sh
 
 header "Setting up environment"
 
-# Handle failures ourselves, so we can dump useful info.
-set +o errexit
-set +o pipefail
-
 install_pipeline_crd
 
 # Run the tests

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -54,10 +54,6 @@ initialize $@
 
 header "Setting up environment"
 
-# Handle failures ourselves, so we can dump useful info.
-set +o errexit
-set +o pipefail
-
 install_build_crd
 
 # Run the tests

--- a/vendor/github.com/knative/test-infra/scripts/markdown-link-check-config.json
+++ b/vendor/github.com/knative/test-infra/scripts/markdown-link-check-config.json
@@ -2,6 +2,9 @@
     "ignorePatterns": [
         {
             "pattern": "^https?://localhost($|[:/].*)"
+        },
+        {
+            "pattern": "^(\\.|\\.\\.)?/.*"
         }
     ]
 }


### PR DESCRIPTION
#458 updated test-infra without updating the release script, thus it's broken.

Addresses https://github.com/knative/test-infra/issues/387

Bonuses:
* update test-infra, so markdown link checker doesn't fail for local references
* remove unnecessary code from e2e test scripts.