### PR TITLE
"BuildStarted" status

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"log"
-	"sync"
 	"time"
 
 	buildclientset "github.com/knative/build/pkg/client/clientset/versioned"
@@ -52,8 +51,6 @@ var (
 	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	masterURL  = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 )
-
-var statusLock sync.Mutex
 
 func main() {
 	flag.Parse()
@@ -129,7 +126,7 @@ func main() {
 		}
 	}
 
-	buildTimeouts := build.NewTimeoutHandler(logger, kubeClient, buildClient, stopCh, &statusLock)
+	buildTimeouts := build.NewTimeoutHandler(logger, kubeClient, buildClient, stopCh)
 	go buildTimeouts.TimeoutHandler()
 
 	var g errgroup.Group

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -296,6 +296,8 @@ const BuildSucceeded = duckv1alpha1.ConditionSucceeded
 
 const BuildCancelled duckv1alpha1.ConditionType = "Cancelled"
 
+const BuildStarted duckv1alpha1.ConditionType = "Started"
+
 var buildCondSet = duckv1alpha1.NewBatchConditionSet()
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -222,9 +222,9 @@ func (c *Reconciler) updateStatus(u *v1alpha1.Build) error {
 	if err != nil {
 		return err
 	}
-	cond := u.Status.GetCondition(v1alpha1.BuildSucceeded)
+	cond := newb.Status.GetCondition(v1alpha1.BuildSucceeded)
 	if cond != nil && cond.Status == corev1.ConditionFalse {
-		return fmt.Errorf("build %q is failed, can't update status", u.Name)
+		return fmt.Errorf("can't update status of failed build %q", newb.Name)
 	}
 	newb.Status = u.Status
 

--- a/pkg/reconciler/build/timeouts_handler.go
+++ b/pkg/reconciler/build/timeouts_handler.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"sync"
 	"time"
 
 	clientset "github.com/knative/build/pkg/client/clientset/versioned"
@@ -18,29 +17,23 @@ type TimeoutSet struct {
 	kubeclientset  kubernetes.Interface
 	buildclientset clientset.Interface
 	stopCh         <-chan struct{}
-	buildStatus    *sync.Mutex
 }
 
 // NewTimeoutHandler returns TimeoutSet filled structure
 func NewTimeoutHandler(logger *zap.SugaredLogger,
 	kubeclientset kubernetes.Interface,
 	buildclientset clientset.Interface,
-	stopCh <-chan struct{},
-	buildStatus *sync.Mutex) *TimeoutSet {
+	stopCh <-chan struct{}) *TimeoutSet {
 	return &TimeoutSet{
 		logger:         logger,
 		kubeclientset:  kubeclientset,
 		buildclientset: buildclientset,
 		stopCh:         stopCh,
-		buildStatus:    buildStatus,
 	}
 }
 
 // TimeoutHandler walks through all namespaces, gets list of builds and checks timeouts
 func (t *TimeoutSet) TimeoutHandler() error {
-	t.buildStatus.Lock()
-	defer t.buildStatus.Unlock()
-
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 

--- a/pkg/reconciler/build/timeouts_handler.go
+++ b/pkg/reconciler/build/timeouts_handler.go
@@ -1,0 +1,206 @@
+package build
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/knative/build/pkg/apis/build/v1alpha1"
+	clientset "github.com/knative/build/pkg/client/clientset/versioned"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type TimeoutSet struct {
+	logger         *zap.SugaredLogger
+	kubeclientset  kubernetes.Interface
+	buildclientset clientset.Interface
+	stopCh         <-chan struct{}
+	buildStatus    *sync.Mutex
+}
+
+func NewTimeoutHandler(logger *zap.SugaredLogger,
+	kubeclientset kubernetes.Interface,
+	buildclientset clientset.Interface,
+	stopCh <-chan struct{},
+	buildStatus *sync.Mutex) *TimeoutSet {
+	return &TimeoutSet{
+		logger:         logger,
+		kubeclientset:  kubeclientset,
+		buildclientset: buildclientset,
+		stopCh:         stopCh,
+		buildStatus:    buildStatus,
+	}
+}
+
+func (t *TimeoutSet) TimeoutHandler() error {
+	namespaces, err := t.kubeclientset.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		t.logger.Errorf("%s", err)
+	}
+	for _, namespace := range namespaces.Items {
+		namespace := namespace
+		if err := t.checkPodTimeouts(namespace.GetName()); err != nil {
+			t.logger.Errorf("%s", err)
+		}
+		go func() {
+			if err := t.watchBuildEvents(namespace.GetName()); err != nil {
+				t.logger.Errorf("%s", err)
+			}
+		}()
+	}
+	// Watching for builds in new namespaces
+	w, err := t.kubeclientset.CoreV1().Namespaces().Watch(metav1.ListOptions{})
+	if err != nil {
+		t.logger.Errorf("%s", err)
+	}
+	for {
+		select {
+		case <-t.stopCh:
+			w.Stop()
+			return nil
+		case event := <-w.ResultChan():
+			namespace, ok := event.Object.(*corev1.Namespace)
+			if !ok {
+				return nil
+			}
+			if event.Type != watch.Added {
+				continue
+			}
+			go func() {
+				if err := t.watchBuildEvents(namespace.GetName()); err != nil {
+					t.logger.Errorf("%s", err)
+				}
+			}()
+		}
+	}
+}
+
+func (t *TimeoutSet) checkPodTimeouts(namespace string) error {
+	builds, err := t.buildclientset.BuildV1alpha1().Builds(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, build := range builds.Items {
+		cond := build.Status.GetCondition(v1alpha1.BuildSucceeded)
+		// Check pod timeout only for ongoing build
+		if cond == nil || cond.Status != corev1.ConditionUnknown {
+			continue
+		}
+		// Build doesn't have pod yet
+		if build.Status.StartTime.IsZero() {
+			continue
+		}
+		timeout := defaultTimeout
+		if build.Spec.Timeout != nil {
+			timeout = build.Spec.Timeout.Duration
+		}
+		runtime := time.Since(build.Status.StartTime.Time)
+		// Build timeout is not exceeded
+		if runtime < timeout {
+			continue
+		}
+		if build.Status.Cluster == nil {
+			continue
+		}
+		if err := t.deletePodAndUpdateStatus(build.Status.Cluster.PodName, &build); err != nil {
+			t.logger.Error(err)
+		}
+	}
+	return nil
+}
+
+func (t *TimeoutSet) watchBuildEvents(namespace string) error {
+	buildEvents, err := t.buildclientset.BuildV1alpha1().Builds(namespace).Watch(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-t.stopCh:
+			buildEvents.Stop()
+			return nil
+		case event := <-buildEvents.ResultChan():
+			build, ok := event.Object.(*v1alpha1.Build)
+			if !ok {
+				return nil
+			}
+			// Watch only for new builds
+			if event.Type != watch.Added {
+				continue
+			}
+			// New build doesn't have pod yet
+			for build.Status.StartTime.IsZero() {
+				if build, err = t.buildclientset.BuildV1alpha1().Builds(namespace).Get(build.Name, metav1.GetOptions{}); err != nil {
+					t.logger.Error(err)
+					continue
+				}
+				// Build started and ended immediately?
+				if !build.Status.CompletionTime.IsZero() {
+					continue
+				}
+				time.Sleep(1 * time.Second)
+			}
+			timeout := defaultTimeout
+			if build.Spec.Timeout != nil {
+				timeout = build.Spec.Timeout.Duration
+			}
+			select {
+			case <-t.stopCh:
+				return nil
+			// wait for timeout
+			case <-time.After(timeout):
+				// Build pod... disappeared?
+				if build.Status.Cluster == nil || len(build.Status.Cluster.PodName) == 0 {
+					continue
+				}
+				if err := t.deletePodAndUpdateStatus(build.Status.Cluster.PodName, build); err != nil {
+					t.logger.Error(err)
+				}
+			}
+		}
+	}
+}
+
+func (t *TimeoutSet) deletePodAndUpdateStatus(pod string, build *v1alpha1.Build) error {
+	t.buildStatus.Lock()
+	defer t.buildStatus.Unlock()
+
+	// Not to update modified object
+	build, err := t.buildclientset.BuildV1alpha1().Builds(build.Namespace).Get(build.Name, metav1.GetOptions{})
+	if err != nil {
+		t.logger.Error(err)
+		return fmt.Errorf("Failed to get build status: %v", err)
+	}
+
+	cond := build.Status.GetCondition(v1alpha1.BuildSucceeded)
+	//Update status only for ongoing build
+	if cond == nil || cond.Status != corev1.ConditionUnknown {
+		return nil
+	}
+
+	message := fmt.Sprintf("Build %q is timeout", build.Name)
+	t.logger.Info(message)
+	build.Status.SetCondition(&duckv1alpha1.Condition{
+		Type:    v1alpha1.BuildSucceeded,
+		Status:  corev1.ConditionFalse,
+		Reason:  "BuildTimeout",
+		Message: message,
+	})
+	build.Status.CompletionTime = &metav1.Time{
+		Time: time.Now(),
+	}
+	if _, err := t.buildclientset.BuildV1alpha1().Builds(build.Namespace).UpdateStatus(build); err != nil {
+		return fmt.Errorf("Failed to update build status: %v", err)
+	}
+	if err := t.kubeclientset.CoreV1().Pods(build.Namespace).Delete(pod, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("Failed to terminate pod: %v", err)
+	}
+	return nil
+}

--- a/pkg/reconciler/build/timeouts_handler.go
+++ b/pkg/reconciler/build/timeouts_handler.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/watch"
-
 	"github.com/knative/build/pkg/apis/build/v1alpha1"
 	clientset "github.com/knative/build/pkg/client/clientset/versioned"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
@@ -17,6 +15,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const checkInterval = 10 * time.Second
+
+// TimeoutSet contains required objects to handle build timeouts
 type TimeoutSet struct {
 	logger         *zap.SugaredLogger
 	kubeclientset  kubernetes.Interface
@@ -25,6 +26,7 @@ type TimeoutSet struct {
 	buildStatus    *sync.Mutex
 }
 
+// NewTimeoutHandler returns TimeoutSet filled structure
 func NewTimeoutHandler(logger *zap.SugaredLogger,
 	kubeclientset kubernetes.Interface,
 	buildclientset clientset.Interface,
@@ -39,45 +41,29 @@ func NewTimeoutHandler(logger *zap.SugaredLogger,
 	}
 }
 
+// TimeoutHandler walks through all namespaces, gets list of builds and checks timeouts
 func (t *TimeoutSet) TimeoutHandler() error {
-	namespaces, err := t.kubeclientset.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err != nil {
-		t.logger.Errorf("%s", err)
-	}
-	for _, namespace := range namespaces.Items {
-		namespace := namespace
-		if err := t.checkPodTimeouts(namespace.GetName()); err != nil {
-			t.logger.Errorf("%s", err)
-		}
-		go func() {
-			if err := t.watchBuildEvents(namespace.GetName()); err != nil {
-				t.logger.Errorf("%s", err)
-			}
-		}()
-	}
-	// Watching for builds in new namespaces
-	w, err := t.kubeclientset.CoreV1().Namespaces().Watch(metav1.ListOptions{})
-	if err != nil {
-		t.logger.Errorf("%s", err)
-	}
+	t.buildStatus.Lock()
+	defer t.buildStatus.Unlock()
+
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-t.stopCh:
-			w.Stop()
 			return nil
-		case event := <-w.ResultChan():
-			namespace, ok := event.Object.(*corev1.Namespace)
-			if !ok {
-				return nil
-			}
-			if event.Type != watch.Added {
+		case <-ticker.C:
+			namespaces, err := t.kubeclientset.CoreV1().Namespaces().List(metav1.ListOptions{})
+			if err != nil {
+				t.logger.Errorf("%s", err)
 				continue
 			}
-			go func() {
-				if err := t.watchBuildEvents(namespace.GetName()); err != nil {
+			for _, namespace := range namespaces.Items {
+				if err := t.checkPodTimeouts(namespace.GetName()); err != nil {
 					t.logger.Errorf("%s", err)
 				}
-			}()
+			}
 		}
 	}
 }
@@ -109,6 +95,7 @@ func (t *TimeoutSet) checkPodTimeouts(namespace string) error {
 		if build.Status.Cluster == nil {
 			continue
 		}
+		t.logger.Infof("Build %s timeout (runtime %s over %s timeout)", build.Name, runtime, timeout)
 		if err := t.deletePodAndUpdateStatus(build.Status.Cluster.PodName, &build); err != nil {
 			t.logger.Error(err)
 		}
@@ -116,82 +103,12 @@ func (t *TimeoutSet) checkPodTimeouts(namespace string) error {
 	return nil
 }
 
-func (t *TimeoutSet) watchBuildEvents(namespace string) error {
-	buildEvents, err := t.buildclientset.BuildV1alpha1().Builds(namespace).Watch(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for {
-		select {
-		case <-t.stopCh:
-			buildEvents.Stop()
-			return nil
-		case event := <-buildEvents.ResultChan():
-			build, ok := event.Object.(*v1alpha1.Build)
-			if !ok {
-				return nil
-			}
-			// Watch only for new builds
-			if event.Type != watch.Added {
-				continue
-			}
-			// New build doesn't have pod yet
-			for build.Status.StartTime.IsZero() {
-				if build, err = t.buildclientset.BuildV1alpha1().Builds(namespace).Get(build.Name, metav1.GetOptions{}); err != nil {
-					t.logger.Error(err)
-					continue
-				}
-				// Build started and ended immediately?
-				if !build.Status.CompletionTime.IsZero() {
-					continue
-				}
-				time.Sleep(1 * time.Second)
-			}
-			timeout := defaultTimeout
-			if build.Spec.Timeout != nil {
-				timeout = build.Spec.Timeout.Duration
-			}
-			select {
-			case <-t.stopCh:
-				return nil
-			// wait for timeout
-			case <-time.After(timeout):
-				// Build pod... disappeared?
-				if build.Status.Cluster == nil || len(build.Status.Cluster.PodName) == 0 {
-					continue
-				}
-				if err := t.deletePodAndUpdateStatus(build.Status.Cluster.PodName, build); err != nil {
-					t.logger.Error(err)
-				}
-			}
-		}
-	}
-}
-
 func (t *TimeoutSet) deletePodAndUpdateStatus(pod string, build *v1alpha1.Build) error {
-	t.buildStatus.Lock()
-	defer t.buildStatus.Unlock()
-
-	// Not to update modified object
-	build, err := t.buildclientset.BuildV1alpha1().Builds(build.Namespace).Get(build.Name, metav1.GetOptions{})
-	if err != nil {
-		t.logger.Error(err)
-		return fmt.Errorf("Failed to get build status: %v", err)
-	}
-
-	cond := build.Status.GetCondition(v1alpha1.BuildSucceeded)
-	//Update status only for ongoing build
-	if cond == nil || cond.Status != corev1.ConditionUnknown {
-		return nil
-	}
-
-	message := fmt.Sprintf("Build %q is timeout", build.Name)
-	t.logger.Info(message)
 	build.Status.SetCondition(&duckv1alpha1.Condition{
 		Type:    v1alpha1.BuildSucceeded,
 		Status:  corev1.ConditionFalse,
 		Reason:  "BuildTimeout",
-		Message: message,
+		Message: fmt.Sprintf("Build %q timeout", build.Name),
 	})
 	build.Status.CompletionTime = &metav1.Time{
 		Time: time.Now(),


### PR DESCRIPTION
Dummy pod name from #519 appears in pod Get response while `startPodForBuild` is being processed (which may take few seconds in rare cases).
Fixes https://github.com/knative/build/issues/542#issuecomment-459802297

## Proposed Changes

*   `BuildStarted` condition instead of dummy status and non-existent pod name 

**Release Note**

```release-note
NONE
```
