### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/clusterbuildtemplate/resources/imagecache.go
+++ b/pkg/reconciler/clusterbuildtemplate/resources/imagecache.go
@@ -19,8 +19,8 @@ package resources
 import (
 	"github.com/knative/build/pkg/apis/build/v1alpha1"
 	buildtemplateresources "github.com/knative/build/pkg/reconciler/buildtemplate/resources"
-	"github.com/knative/pkg/system"
 	caching "github.com/knative/caching/pkg/apis/caching/v1alpha1"
+	"github.com/knative/pkg/system"
 )
 
 func MakeImageCaches(bt *v1alpha1.ClusterBuildTemplate) []caching.Image {

--- a/pkg/reconciler/clusterbuildtemplate/resources/imagecache_test.go
+++ b/pkg/reconciler/clusterbuildtemplate/resources/imagecache_test.go
@@ -24,9 +24,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/knative/build/pkg/apis/build/v1alpha1"
+	caching "github.com/knative/caching/pkg/apis/caching/v1alpha1"
 	"github.com/knative/pkg/system"
 	_ "github.com/knative/pkg/system/testing"
-	caching "github.com/knative/caching/pkg/apis/caching/v1alpha1"
 )
 
 func TestMakeImageCache(t *testing.T) {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
