### PR TITLE
Don't generate dummy pod name

### DIFF
--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -186,6 +186,11 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 		if err = c.validateBuild(build); err != nil {
 			logger.Errorf("Failed to validate build: %v", err)
+			build.Status = v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "",
+				},
+			}
 			build.Status.SetCondition(&duckv1alpha1.Condition{
 				Type:    v1alpha1.BuildSucceeded,
 				Status:  corev1.ConditionFalse,

--- a/pkg/reconciler/build/resources/pod.go
+++ b/pkg/reconciler/build/resources/pod.go
@@ -342,11 +342,11 @@ func MakePod(build *v1alpha1.Build, kubeclient kubernetes.Interface) (*corev1.Po
 		return nil, err
 	}
 
-	// Add a unique suffix to avoid confusion when a build
-	// is deleted and re-created with the same name.
-	// We don't use GenerateName here because k8s fakes don't support it.
-	podName, err := GetUniquePodName(build.Name)
-	if err != nil {
+	var podName string
+	// Use podName from build status structure if passed, otherwise generate new unique name
+	if build.Status.Cluster != nil && build.Status.Cluster.PodName != "" {
+		podName = build.Status.Cluster.PodName
+	} else if podName, err = GetUniquePodName(build.Name); err != nil {
 		return nil, err
 	}
 

--- a/pkg/reconciler/build/resources/pod.go
+++ b/pkg/reconciler/build/resources/pod.go
@@ -343,11 +343,10 @@ func MakePod(build *v1alpha1.Build, kubeclient kubernetes.Interface) (*corev1.Po
 	}
 
 	var podName string
-	// Use podName from build status structure if passed, otherwise generate new unique name
 	if build.Status.Cluster != nil && build.Status.Cluster.PodName != "" {
 		podName = build.Status.Cluster.PodName
-	} else if podName, err = GetUniquePodName(build.Name); err != nil {
-		return nil, err
+	} else {
+		return nil, fmt.Errorf("Can't create pod for build %q: pod name not set", build.Name)
 	}
 
 	return &corev1.Pod{

--- a/pkg/reconciler/build/resources/pod_test.go
+++ b/pkg/reconciler/build/resources/pod_test.go
@@ -474,6 +474,11 @@ func TestMakePod(t *testing.T) {
 					Annotations: c.bAnnotations,
 				},
 				Spec: c.b,
+				Status: v1alpha1.BuildStatus{
+					Cluster: &v1alpha1.ClusterSpec{
+						PodName: "build-name-pod-616161",
+					},
+				},
 			}
 			got, err := MakePod(b, cs)
 			if err != c.wantErr {

--- a/pkg/reconciler/build/validation_test.go
+++ b/pkg/reconciler/build/validation_test.go
@@ -50,6 +50,11 @@ func TestValidateBuild(t *testing.T) {
 					}},
 				},
 			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
+				},
+			},
 		},
 		tmpl: &v1alpha1.BuildTemplate{
 			Spec: v1alpha1.BuildTemplateSpec{
@@ -71,6 +76,11 @@ func TestValidateBuild(t *testing.T) {
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
 				}},
+			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
+				},
 			},
 		},
 		tmpl: &v1alpha1.BuildTemplate{
@@ -94,6 +104,11 @@ func TestValidateBuild(t *testing.T) {
 				Template: &v1alpha1.TemplateInstantiationSpec{
 					Name: "foo-bar",
 					Kind: v1alpha1.ClusterBuildTemplateKind,
+				},
+			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
 				},
 			},
 		},
@@ -129,6 +144,11 @@ func TestValidateBuild(t *testing.T) {
 					Name: "template",
 				},
 			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
+				},
+			},
 		},
 		reason: "TemplateAndSteps",
 	}, {
@@ -140,6 +160,11 @@ func TestValidateBuild(t *testing.T) {
 						Name:  "foo",
 						Value: "hello",
 					}},
+				},
+			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
 				},
 			},
 		},
@@ -166,6 +191,11 @@ func TestValidateBuild(t *testing.T) {
 					}},
 				},
 			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
+				},
+			},
 		},
 		tmpl: &v1alpha1.BuildTemplate{
 			ObjectMeta: metav1.ObjectMeta{Name: "template"},
@@ -181,6 +211,11 @@ func TestValidateBuild(t *testing.T) {
 						Name:  "foo",
 						Value: "hello",
 					}},
+				},
+			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
 				},
 			},
 		},
@@ -204,6 +239,11 @@ func TestValidateBuild(t *testing.T) {
 					Kind: "BuildTemplate",
 				},
 			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
+				},
+			},
 		},
 		tmpl: &v1alpha1.BuildTemplate{
 			ObjectMeta: metav1.ObjectMeta{Name: "empty-default"},
@@ -223,6 +263,11 @@ func TestValidateBuild(t *testing.T) {
 					Kind: "ClusterBuildTemplate",
 				},
 			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
+				},
+			},
 		},
 		ctmpl: &v1alpha1.ClusterBuildTemplate{
 			ObjectMeta: metav1.ObjectMeta{Name: "empty-default"},
@@ -239,6 +284,11 @@ func TestValidateBuild(t *testing.T) {
 			Spec: v1alpha1.BuildSpec{
 				// ServiceAccountName will default to "default"
 				Steps: []corev1.Container{{Image: "hello"}},
+			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
+				},
 			},
 		},
 		sa: &corev1.ServiceAccount{
@@ -276,6 +326,11 @@ func TestValidateBuild(t *testing.T) {
 			Spec: v1alpha1.BuildSpec{
 				ServiceAccountName: "serviceaccount",
 				Steps:              []corev1.Container{{Image: "hello"}},
+			},
+			Status: v1alpha1.BuildStatus{
+				Cluster: &v1alpha1.ClusterSpec{
+					PodName: "foo",
+				},
 			},
 		},
 		sa: &corev1.ServiceAccount{


### PR DESCRIPTION
Fixes #542 

Dummy pod name from #519 makes API response unreliable:  
https://github.com/knative/build/issues/542#issuecomment-459802297

## Proposed Changes

`MakePod` function uses `build.Status.Cluster.PodName` to create new pod instead of generating new unique name

**Release Note**

```release-note
NONE
```
