### PR TITLE
Fix typo in .ko.yaml.release

### DIFF
--- a/.ko.yaml.release
+++ b/.ko.yaml.release
@@ -1,3 +1,3 @@
 baseImageOverrides:
-  github.com/knative/build/cmd/creds-init: gcr.io/knative-release/github.com/knative/build/build-base:latest
-  github.com/knative/build/cmd/git-init: gcr.io/knative-release/github.com/knative/build/build-base:latest
+  github.com/knative/build/cmd/creds-init: gcr.io/knative-releases/github.com/knative/build/build-base:latest
+  github.com/knative/build/cmd/git-init: gcr.io/knative-releases/github.com/knative/build/build-base:latest


### PR DESCRIPTION
Related to #566 (not sure if it's the full fix)

This seems to be related to the broken release because the prow job that autoreleased `release-0.4` branch logged this line:

```
I0220 16:35:17.750] 2019/02/20 16:35:17 error processing import paths in "config/999-cache.yaml": UNKNOWN: Project 'projects/knative-release' not found or deleted.
```

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
