### PR TITLE
Update test-infra, use its function for pod logs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -252,14 +252,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7ed6c383bee16b6106f09f26c29379046c1fff35cecd7842c2712e38692e422d"
+  digest = "1:ae14885490829a664d0f19dc78852719e1d7221144e69eaa8c201e854028487c"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "0600862ee70f8f2e826f1024faae8f707cc814c7"
+  revision = "cfcb8c3d5b2eb146c40e5d8a828520f240b35747"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,22 +30,13 @@ source $(dirname $0)/e2e-common.sh
 
 # Helper functions.
 
-function dump_app_logs() {
-  echo ">>> Knative Build $1 logs:"
-  for pod in $(get_app_pods "$1" knative-build)
-  do
-    echo ">>> Pod: $pod"
-    kubectl -n knative-build logs "$pod" -c "$1"
-  done
-}
-
 function dump_extra_cluster_state() {
   echo ">>> Builds:"
   kubectl get builds -o yaml --all-namespaces
   echo ">>> Pods:"
   kubectl get pods -o yaml --all-namespaces
 
-  dump_app_logs controller
+  dump_app_logs controller knative-build
 }
 
 # Script entry point.

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -200,6 +200,29 @@ function get_app_pods() {
   kubectl get pods ${namespace} --selector=app=$1 --output=jsonpath="{.items[*].metadata.name}"
 }
 
+# Capitalize the first letter of each word.
+# Parameters: $1..$n - words to capitalize.
+function capitalize() {
+  local capitalized=()
+  for word in $@; do
+    local initial="$(echo ${word:0:1}| tr 'a-z' 'A-Z')"
+    capitalized+=("${initial}${word:1}")
+  done
+  echo "${capitalized[@]}"
+}
+
+# Dumps pod logs for the given app.
+# Parameters: $1 - app name.
+#             $2 - namespace.
+function dump_app_logs() {
+  echo ">>> ${REPO_NAME_FORMATTED} $1 logs:"
+  for pod in $(get_app_pods "$1" "$2")
+  do
+    echo ">>> Pod: $pod"
+    kubectl -n "$2" logs "$pod" -c "$1"
+  done
+}
+
 # Sets the given user as cluster admin.
 # Parameters: $1 - user
 #             $2 - cluster name
@@ -392,3 +415,4 @@ function get_canonical_path() {
 # These MUST come last.
 
 readonly _TEST_INFRA_SCRIPTS_DIR="$(dirname $(get_canonical_path ${BASH_SOURCE[0]}))"
+readonly REPO_NAME_FORMATTED="Knative $(capitalize ${REPO_NAME//-/})"

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -31,18 +31,6 @@ function banner() {
     make_banner "@" "$1"
 }
 
-# Capitalize the first letter of each word.
-# Parameters: $1..$n - words to capitalize.
-function capitalize() {
-  local words=("$1")
-  local capitalized=()
-  for word in $@; do
-    local initial="$(echo ${word:0:1}| tr 'a-z' 'A-Z')"
-    capitalized+=("${initial}${word:1}")
-  done
-  echo "${capitalized[@]}"
-}
-
 # Tag images in the yaml files if $TAG is not empty.
 # $KO_DOCKER_REPO is the registry containing the images to tag with $TAG.
 # Parameters: $1..$n - yaml files to parse for images.
@@ -407,7 +395,7 @@ function main() {
 # Parameters: $1..$n - YAML files to add to the release.
 function publish_to_github() {
   (( PUBLISH_TO_GITHUB )) || return 0
-  local title="Knative $(capitalize ${REPO_NAME//-/ }) release ${TAG}"
+  local title="${REPO_NAME_FORMATTED} release ${TAG}"
   local attachments=()
   local description="$(mktemp)"
   local attachments_dir="$(mktemp -d)"


### PR DESCRIPTION
## Proposed Changes

* Update to latest test-infra commit 
* Use test-infra's generalized `dump_app_logs` function and remove Build's implementation

<!--
Request Prow to automatically lint any go code in this PR:

/lint
--> 