### PR TITLE
Set memory limits

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -45,9 +45,9 @@ spec:
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging
-       resources:
-         limits:
-           memory: 1000Mi
+        resources:
+          limits:
+            memory: 1000Mi
       volumes:
         - name: config-logging
           configMap:

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -45,6 +45,9 @@ spec:
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging
+       resources:
+         limits:
+           memory: 1000Mi
       volumes:
         - name: config-logging
           configMap:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -46,6 +46,9 @@ spec:
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging
+        resources:
+          limits:
+            memory: 1000Mi
       volumes:
         - name: config-logging
           configMap:


### PR DESCRIPTION
This is the "build" version of https://github.com/knative/serving/pull/3332

We're seeing OOM issues at the Node level when we don't set the limit.
This will allow the pod to restart gracefully w/o taking down the entire node.

I'm not stuck on the specific value so we can pick a different one.

Signed-off-by: Doug Davis <dug@us.ibm.com>

**Release Note**

```release-note
NONE
```
/lint
