### PR TITLE
Remove unnecessary build-reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,3 @@
 
 approvers:
 - build-approvers
-
-reviewers:
-- build-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,10 +3,6 @@ aliases:
   - imjasonh
   - mattmoor
   - shashwathi
-  build-reviewers:
-  - imjasonh
-  - mattmoor
-  - shashwathi
 
   productivity-approvers:
   - adrcunha


### PR DESCRIPTION
Keep the repo reviewers as they were before (as /hack and /test are fine).

Part of knative/test-infra#579