### PR TITLE
Make a small adjustment to hack/update-deps.sh

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -337,7 +337,8 @@
   revision = "b6c8f4851e3fb13987782cf8014316141e42fbd3"
 
 [[projects]]
-  digest = "1:d8523cc44ff81851749411eba077c1fe726303a0be63304650a82aa5bde73597"
+  branch = "master"
+  digest = "1:a3cabcef7cdb39039c0e37353e1d1ac257f4fa926176494ca4bae3f616c3e820"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -379,7 +380,7 @@
     "webhook",
   ]
   pruneopts = "T"
-  revision = "2353d3bfc0b7766de2bf87358cbe2e8611709369"
+  revision = "139b81e637e39b1d7c1763e793e13b364f2dd26a"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,8 +53,7 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-06-08
-  revision = "2353d3bfc0b7766de2bf87358cbe2e8611709369"
+  branch = "master"
 
 [[override]]
   name = "contrib.go.opencensus.io/exporter/stackdriver"

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/github.com/knative/test-infra/scripts/library.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
-
-cd ${REPO_ROOT_DIR}
+cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/breaking-change.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/breaking-change.md
@@ -1,0 +1,22 @@
+---
+name: Breaking Change
+about: Makes a breaking change to knative/pkg
+title: ''
+labels: 
+assignees: 'mattmoor'
+
+---
+
+BREAKING CHANGES MUST STAGE CHANGES ONTO DOWNSTREAM
+KNATIVE REPOSITORIES
+
+
+| Repo              | Pull Request                   |
+|-------------------|--------------------------------|
+| Build             | knative/build#1234             |
+| Eventing          | knative/eventing#1234          |
+| Serving           | knative/serving#1234           |
+| Sample Controller | knative/sample-controller#1234 |
+
+
+cc @n3wscott @jasonhall

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/bug-fix.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/bug-fix.md
@@ -1,0 +1,10 @@
+---
+name: Bug Fix
+about: Fixes a bug in knative/pkg
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+
+Fixes:

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/normal-change.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/normal-change.md
@@ -1,0 +1,8 @@
+---
+name: Normal Change
+about: Makes a boring change to the repo.
+title: ''
+labels: 
+assignees: ''
+
+---

--- a/vendor/github.com/knative/pkg/.github/pull-request-template.md
+++ b/vendor/github.com/knative/pkg/.github/pull-request-template.md
@@ -1,6 +1,0 @@
-<!--
-Pro-tip: To automatically close issues when a PR is merged,
-include the following in your PR description:
-
-Fixes: <LINK TO ISSUE>
--->

--- a/vendor/github.com/knative/pkg/Gopkg.lock
+++ b/vendor/github.com/knative/pkg/Gopkg.lock
@@ -857,7 +857,7 @@
   version = "kubernetes-1.12.6"
 
 [[projects]]
-  digest = "1:07be043078c2dc2ee33e81278b264a84f364c6d711811d2932aa42212fc4f2ae"
+  digest = "1:b7dd0420e85cb2968ffb945f2810ea6c796dc2a08660618e2200c08c596f0624"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1005,11 +1005,9 @@
     "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
-    "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
     "testing",
-    "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
     "tools/clientcmd",
@@ -1027,7 +1025,6 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
-    "util/jsonpath",
     "util/retry",
     "util/workqueue",
   ]
@@ -1174,12 +1171,13 @@
     "k8s.io/client-go/informers/apps/v1",
     "k8s.io/client-go/informers/autoscaling/v1",
     "k8s.io/client-go/informers/autoscaling/v2beta1",
+    "k8s.io/client-go/informers/batch/v1",
     "k8s.io/client-go/informers/core/v1",
+    "k8s.io/client-go/informers/rbac/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
     "k8s.io/client-go/kubernetes/typed/core/v1",
-    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",

--- a/vendor/github.com/knative/pkg/hack/update-deps.sh
+++ b/vendor/github.com/knative/pkg/hack/update-deps.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/github.com/knative/test-infra/scripts/library.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
-
-cd ${REPO_ROOT_DIR}
+cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/fake/fake.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
+)
+
+var Get = job.Get
+
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := fake.Get(ctx)
+	inf := f.Batch().V1().Jobs()
+	return context.WithValue(ctx, job.Key{}, inf), inf.Informer()
+}

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/job.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/job.go
@@ -14,40 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factory
+package job
 
 import (
 	"context"
 
-	"github.com/knative/pkg/logging"
-
-	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	batchv1 "k8s.io/client-go/informers/batch/v1"
 
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/clients/apiextclient"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
-	injection.Default.RegisterInformerFactory(withInformerFactory)
+	injection.Default.RegisterInformer(withInformer)
 }
 
 // Key is used as the key for associating information
 // with a context.Context.
 type Key struct{}
 
-func withInformerFactory(ctx context.Context) context.Context {
-	axc := apiextclient.Get(ctx)
-	return context.WithValue(ctx, Key{},
-		informers.NewSharedInformerFactory(axc, controller.GetResyncPeriod(ctx)))
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Batch().V1().Jobs()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
-// Get extracts the Kubernetes Api Extensions InformerFactory from the context.
-func Get(ctx context.Context) informers.SharedInformerFactory {
+// Get extracts the Kubernetes Job informer from the context.
+func Get(ctx context.Context) batchv1.JobInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (informers.SharedInformerFactory)(nil))
+			"Unable to fetch %T from context.", (batchv1.JobInformer)(nil))
 	}
-	return untyped.(informers.SharedInformerFactory)
+	return untyped.(batchv1.JobInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/namespace/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/namespace/fake/fake.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/corev1/namespace"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
+)
+
+var Get = namespace.Get
+
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := fake.Get(ctx)
+	inf := f.Core().V1().Namespaces()
+	return context.WithValue(ctx, namespace.Key{}, inf), inf.Informer()
+}

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/namespace/namespace.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/namespace/namespace.go
@@ -14,40 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factory
+package namespace
 
 import (
 	"context"
 
-	"github.com/knative/pkg/logging"
-
-	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	corev1 "k8s.io/client-go/informers/core/v1"
 
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/clients/apiextclient"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
-	injection.Default.RegisterInformerFactory(withInformerFactory)
+	injection.Default.RegisterInformer(withInformer)
 }
 
 // Key is used as the key for associating information
 // with a context.Context.
 type Key struct{}
 
-func withInformerFactory(ctx context.Context) context.Context {
-	axc := apiextclient.Get(ctx)
-	return context.WithValue(ctx, Key{},
-		informers.NewSharedInformerFactory(axc, controller.GetResyncPeriod(ctx)))
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Core().V1().Namespaces()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
-// Get extracts the Kubernetes Api Extensions InformerFactory from the context.
-func Get(ctx context.Context) informers.SharedInformerFactory {
+// Get extracts the Kubernetes Namespace informer from the context.
+func Get(ctx context.Context) corev1.NamespaceInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (informers.SharedInformerFactory)(nil))
+			"Unable to fetch %T from context.", (corev1.NamespaceInformer)(nil))
 	}
-	return untyped.(informers.SharedInformerFactory)
+	return untyped.(corev1.NamespaceInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount/fake/fake.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
+)
+
+var Get = serviceaccount.Get
+
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := fake.Get(ctx)
+	inf := f.Core().V1().ServiceAccounts()
+	return context.WithValue(ctx, serviceaccount.Key{}, inf), inf.Informer()
+}

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount/service.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/corev1/serviceaccount/service.go
@@ -14,40 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factory
+package serviceaccount
 
 import (
 	"context"
 
-	"github.com/knative/pkg/logging"
-
-	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	corev1 "k8s.io/client-go/informers/core/v1"
 
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"
-	"github.com/knative/pkg/injection/clients/apiextclient"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
 )
 
 func init() {
-	injection.Default.RegisterInformerFactory(withInformerFactory)
+	injection.Default.RegisterInformer(withInformer)
 }
 
 // Key is used as the key for associating information
 // with a context.Context.
 type Key struct{}
 
-func withInformerFactory(ctx context.Context) context.Context {
-	axc := apiextclient.Get(ctx)
-	return context.WithValue(ctx, Key{},
-		informers.NewSharedInformerFactory(axc, controller.GetResyncPeriod(ctx)))
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Core().V1().ServiceAccounts()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
-// Get extracts the Kubernetes Api Extensions InformerFactory from the context.
-func Get(ctx context.Context) informers.SharedInformerFactory {
+// Get extracts the Kubernetes Service Account informer from the context.
+func Get(ctx context.Context) corev1.ServiceAccountInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panicf(
-			"Unable to fetch %T from context.", (informers.SharedInformerFactory)(nil))
+			"Unable to fetch %T from context.", (corev1.ServiceAccountInformer)(nil))
 	}
-	return untyped.(informers.SharedInformerFactory)
+	return untyped.(corev1.ServiceAccountInformer)
 }

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/rolebinding/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/rolebinding/fake/fake.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
+	"github.com/knative/pkg/injection/informers/kubeinformers/rbacv1/rolebinding"
+)
+
+var Get = rolebinding.Get
+
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := fake.Get(ctx)
+	inf := f.Rbac().V1().RoleBindings()
+	return context.WithValue(ctx, rolebinding.Key{}, inf), inf.Informer()
+}

--- a/vendor/github.com/knative/pkg/injection/sharedmain/main.go
+++ b/vendor/github.com/knative/pkg/injection/sharedmain/main.go
@@ -24,9 +24,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"


### PR DESCRIPTION
This form should be more hospitable to running things to auto-update `knative/pkg` and `knative/test-infra`.

I canaried this change in `knative/sample-controller`, and was able to produce: https://github.com/knative/sample-controller/pull/11